### PR TITLE
bugfix/token-subject

### DIFF
--- a/src/controllers/application.ts
+++ b/src/controllers/application.ts
@@ -157,10 +157,11 @@ const setLicenceHolderMagicLinkDetails = async (
   const privateKey = await jwk.getPrivateKey({type: 'pem'});
 
   // Create JWT.
-  const token = jwt.sign({subject: `${applicationId}`}, privateKey as string, {
+  const token = jwt.sign({}, privateKey as string, {
     algorithm: 'ES256',
     expiresIn: '28 days',
     noTimestamp: true,
+    subject: `${applicationId}`,
   });
 
   // Append JWT to confirm url.


### PR DESCRIPTION
##  Add the subject to the token correctly

The correct claim for the "subject" of a token is "sub". This can either be added as a specific "sub" field in the encoded object or the "subject" field in the options object, but not as a "subject" field in the encoded object.