### PR TITLE
Bugfix/fix missing permitted species

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@
 # We're deploying to the 16-alpine image, so do our building on it too.
 FROM node:16-alpine as builder
 
+# Using npm 8.1.2 as there seems to be an issue with 8.3.1 shipped with node:16-alpine
+# that causes an ERR_SOCKET_TIMEOUT just after the npm ci command completes.
+RUN npm install -g npm@8.1.2
+
 # By default, we want to do everything in a non-privileged user, so go to their
 # home dir and drop to their account.
 WORKDIR /home/node
@@ -15,7 +19,7 @@ COPY --chown=node:node ./src ./src
 
 # Install all the build, test & run dependencies.
 COPY --chown=node:node package*.json ./
-RUN npm ci
+RUN npm ci --loglevel verbose
 
 # Build the `.js` and `.css` from our `.ts` and `.scss` files.
 COPY --chown=node:node tsconfig.json ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,7 @@
 # We're deploying to the 16-alpine image, so do our building on it too.
 FROM node:16-alpine as builder
 
-# Using npm 8.1.2 as there seems to be an issue with 8.3.1 shipped with node:16-alpine
-# that causes an ERR_SOCKET_TIMEOUT just after the npm ci command completes.
-RUN npm install -g npm@8.1.2
+
 
 # By default, we want to do everything in a non-privileged user, so go to their
 # home dir and drop to their account.
@@ -19,7 +17,7 @@ COPY --chown=node:node ./src ./src
 
 # Install all the build, test & run dependencies.
 COPY --chown=node:node package*.json ./
-RUN npm ci --loglevel verbose
+RUN npm ci
 
 # Build the `.js` and `.css` from our `.ts` and `.scss` files.
 COPY --chown=node:node tsconfig.json ./

--- a/src/config/jwk.ts
+++ b/src/config/jwk.ts
@@ -86,7 +86,7 @@ interface KeyOptions {
  */
 const getPrivateKey = async (options?: KeyOptions): Promise<string | JsonWebKey> => {
   // Are we running in developer/test mode?
-  if (process.env.NODE_ENV !== 'production') {
+  if (process.env.NODE_ENV === 'production') {
     // Does the caller want the test private key as a JWK?
     if (options && options.type === 'jwk') {
       return testKeyPair;

--- a/src/config/jwk.ts
+++ b/src/config/jwk.ts
@@ -86,7 +86,7 @@ interface KeyOptions {
  */
 const getPrivateKey = async (options?: KeyOptions): Promise<string | JsonWebKey> => {
   // Are we running in developer/test mode?
-  if (process.env.NODE_ENV === 'production') {
+  if (process.env.NODE_ENV !== 'production') {
     // Does the caller want the test private key as a JWK?
     if (options && options.type === 'jwk') {
       return testKeyPair;

--- a/src/controllers/application.ts
+++ b/src/controllers/application.ts
@@ -763,19 +763,17 @@ const ApplicationController = {
           await PActivity.destroy({where: {id: pCommonGullActivity.id}, transaction: t});
         }
 
-        const pGreatBlackBackedGullActivity = await PActivity.findByPk(
-          pSpecies.GreatBlackBackedGullId,
-          {transaction: t},
-        );
+        const pGreatBlackBackedGullActivity = await PActivity.findByPk(pSpecies.GreatBlackBackedGullId, {
+          transaction: t,
+        });
         if (pGreatBlackBackedGullActivity) {
           // Soft Delete any PermittedActivity attached to the application/license.
           await PActivity.destroy({where: {id: pGreatBlackBackedGullActivity.id}, transaction: t});
         }
 
-        const pLesserBlackBackedGullActivity = await PActivity.findByPk(
-          pSpecies.LesserBlackBackedGullId,
-          {transaction: t},
-        );
+        const pLesserBlackBackedGullActivity = await PActivity.findByPk(pSpecies.LesserBlackBackedGullId, {
+          transaction: t,
+        });
         if (pLesserBlackBackedGullActivity) {
           // Soft Delete any PermittedActivity attached to the application/license.
           await PActivity.destroy({where: {id: pLesserBlackBackedGullActivity.id}, transaction: t});
@@ -924,10 +922,9 @@ const ApplicationController = {
           await PActivity.destroy({where: {id: pCommonGullActivity.id}, force: true, transaction: t});
         }
 
-        const pGreatBlackBackedGullActivity = await PActivity.findByPk(
-          pSpecies.GreatBlackBackedGullId,
-          {transaction: t},
-        );
+        const pGreatBlackBackedGullActivity = await PActivity.findByPk(pSpecies.GreatBlackBackedGullId, {
+          transaction: t,
+        });
         if (pGreatBlackBackedGullActivity) {
           // Delete any PermittedActivity record attached to the application/license.
           await PActivity.destroy({
@@ -937,10 +934,9 @@ const ApplicationController = {
           });
         }
 
-        const pLesserBlackBackedGullActivity = await PActivity.findByPk(
-          pSpecies.LesserBlackBackedGullId,
-          {transaction: t},
-        );
+        const pLesserBlackBackedGullActivity = await PActivity.findByPk(pSpecies.LesserBlackBackedGullId, {
+          transaction: t,
+        });
         if (pLesserBlackBackedGullActivity) {
           // Delete any PermittedActivity record attached to the application/license.
           await PActivity.destroy({

--- a/src/controllers/application.ts
+++ b/src/controllers/application.ts
@@ -79,7 +79,10 @@ const setLicenceHolderDirectEmailDetails = (newApplication: any, licenceHolderCo
   return {
     licenceName: licenceHolderContact.name,
     applicationDate: createDisplayDate(new Date(newApplication.createdAt)),
-    siteName: siteAddress.addressLine1,
+    siteAddressLine1: siteAddress.addressLine1,
+    siteAddressLine2: siteAddress.addressLine2,
+    siteAddressTown: siteAddress.addressTown,
+    sitePostcode: siteAddress.postcode,
     id: newApplication.id,
   };
 };
@@ -106,7 +109,10 @@ const setHolderApplicantConfirmEmailDetails = (
     lhName: licenceHolderContact.name,
     laName: onBehalfContact.name,
     applicationDate: createDisplayDate(new Date(createdAt)),
-    siteName: siteAddress.addressLine1,
+    siteAddressLine1: siteAddress.addressLine1,
+    siteAddressLine2: siteAddress.addressLine2,
+    siteAddressTown: siteAddress.addressTown,
+    sitePostcode: siteAddress.postcode,
     id,
   };
 };

--- a/src/controllers/application.ts
+++ b/src/controllers/application.ts
@@ -10,11 +10,11 @@ const {
   Contact,
   Address,
   Activity,
-  PermittedActivity,
+  PActivity,
   Issue,
   Measure,
   Species,
-  PermittedSpecies,
+  PSpecies,
   Assessment,
   License,
   LicenseAdvisory,
@@ -52,7 +52,7 @@ interface ApplicationInterface {
   LicenceHolderAddressId: number;
   SiteAddressId: number;
   SpeciesId: number;
-  PermittedSpeciesId: number;
+  PSpeciesId: number;
   isResidentialSite: boolean;
   siteType: string;
   previousLicence: boolean;
@@ -300,28 +300,28 @@ const ApplicationController = {
           ],
         },
         {
-          model: PermittedSpecies,
-          as: 'PermittedSpecies',
+          model: PSpecies,
+          as: 'PSpecies',
           include: [
             {
-              model: PermittedActivity,
-              as: 'PermittedHerringGull',
+              model: PActivity,
+              as: 'PHerringGull',
             },
             {
-              model: PermittedActivity,
-              as: 'PermittedBlackHeadedGull',
+              model: PActivity,
+              as: 'PBlackHeadedGull',
             },
             {
-              model: PermittedActivity,
-              as: 'PermittedCommonGull',
+              model: PActivity,
+              as: 'PCommonGull',
             },
             {
-              model: PermittedActivity,
-              as: 'PermittedGreatBlackBackedGull',
+              model: PActivity,
+              as: 'PGreatBlackBackedGull',
             },
             {
-              model: PermittedActivity,
-              as: 'PermittedLesserBlackBackedGull',
+              model: PActivity,
+              as: 'PLesserBlackBackedGull',
             },
           ],
         },
@@ -425,11 +425,11 @@ const ApplicationController = {
    * @param {any | undefined} commonActivity The common gull activities to be licensed.
    * @param {any | undefined} greatBlackBackedActivity The great black-backed gull activities to be licensed.
    * @param {any | undefined} lesserBlackBackedActivity The lesser black-backed gull activities to be licensed.
-   * @param {any | undefined} permittedHerringActivity The herring gull activities to be licensed.
-   * @param {any | undefined} permittedBlackHeadedActivity The black-headed gull activities to be licensed.
-   * @param {any | undefined} permittedCommonActivity The common gull activities to be licensed.
-   * @param {any | undefined} permittedGreatBlackBackedActivity The great black-backed gull activities to be licensed.
-   * @param {any | undefined} permittedLesserBlackBackedActivity The lesser black-backed gull activities to be licensed.
+   * @param {any | undefined} pHerringActivity The herring gull activities to be licensed.
+   * @param {any | undefined} pBlackHeadedActivity The black-headed gull activities to be licensed.
+   * @param {any | undefined} pCommonActivity The common gull activities to be licensed.
+   * @param {any | undefined} pGreatBlackBackedActivity The great black-backed gull activities to be licensed.
+   * @param {any | undefined} pLesserBlackBackedActivity The lesser black-backed gull activities to be licensed.
    * @param {any | undefined} measure The measures taken / not taken details.
    * @param {any | undefined} incomingApplication The application details.
    * @param {string} confirmBaseUrl The micro-frontend we want to send the lh to to confirm their licence.
@@ -446,11 +446,11 @@ const ApplicationController = {
     commonActivity: any | undefined,
     greatBlackBackedActivity: any | undefined,
     lesserBlackBackedActivity: any | undefined,
-    permittedHerringActivity: any | undefined,
-    permittedBlackHeadedActivity: any | undefined,
-    permittedCommonActivity: any | undefined,
-    permittedGreatBlackBackedActivity: any | undefined,
-    permittedLesserBlackBackedActivity: any | undefined,
+    pHerringActivity: any | undefined,
+    pBlackHeadedActivity: any | undefined,
+    pCommonActivity: any | undefined,
+    pGreatBlackBackedActivity: any | undefined,
+    pLesserBlackBackedActivity: any | undefined,
     measure: any,
     incomingApplication: any,
     confirmBaseUrl: string,
@@ -462,7 +462,7 @@ const ApplicationController = {
       GreatBlackBackedGullId: undefined,
       LesserBlackBackedGullId: undefined,
     };
-    const permittedSpeciesIds: SpeciesIds = {
+    const pSpeciesIds: SpeciesIds = {
       HerringGullId: undefined,
       BlackHeadedGullId: undefined,
       CommonGullId: undefined,
@@ -491,53 +491,53 @@ const ApplicationController = {
       // Add any species specific activities to the DB and get their IDs.
       if (herringActivity) {
         const herringGull = await Activity.create(herringActivity, {transaction: t});
-        const permittedHerringGull = await PermittedActivity.create(permittedHerringActivity, {transaction: t});
+        const pHerringGull = await PActivity.create(pHerringActivity, {transaction: t});
         speciesIds.HerringGullId = herringGull.id;
-        permittedSpeciesIds.HerringGullId = permittedHerringGull.id;
+        pSpeciesIds.HerringGullId = pHerringGull.id;
       }
 
       if (blackHeadedActivity) {
         const blackHeadedGull = await Activity.create(blackHeadedActivity, {transaction: t});
-        const permittedBlackHeadedGull = await PermittedActivity.create(permittedBlackHeadedActivity, {transaction: t});
+        const pBlackHeadedGull = await PActivity.create(pBlackHeadedActivity, {transaction: t});
         speciesIds.BlackHeadedGullId = blackHeadedGull.id;
-        permittedSpeciesIds.BlackHeadedGullId = permittedBlackHeadedGull.id;
+        pSpeciesIds.BlackHeadedGullId = pBlackHeadedGull.id;
       }
 
       if (commonActivity) {
         const commonGull = await Activity.create(commonActivity, {transaction: t});
-        const permittedCommonGull = await PermittedActivity.create(permittedCommonActivity, {transaction: t});
+        const pCommonGull = await PActivity.create(pCommonActivity, {transaction: t});
         speciesIds.CommonGullId = commonGull.id;
-        permittedSpeciesIds.CommonGullId = permittedCommonGull.id;
+        pSpeciesIds.CommonGullId = pCommonGull.id;
       }
 
       if (greatBlackBackedActivity) {
         const greatBlackBackedGull = await Activity.create(greatBlackBackedActivity, {transaction: t});
-        const permittedGreatBlackBackedGull = await PermittedActivity.create(permittedGreatBlackBackedActivity, {
+        const pGreatBlackBackedGull = await PActivity.create(pGreatBlackBackedActivity, {
           transaction: t,
         });
         speciesIds.GreatBlackBackedGullId = greatBlackBackedGull.id;
-        permittedSpeciesIds.GreatBlackBackedGullId = permittedGreatBlackBackedGull.id;
+        pSpeciesIds.GreatBlackBackedGullId = pGreatBlackBackedGull.id;
       }
 
       if (lesserBlackBackedActivity) {
         const lesserBlackBackedGull = await Activity.create(lesserBlackBackedActivity, {transaction: t});
-        const permittedLesserBlackBackedGull = await PermittedActivity.create(permittedLesserBlackBackedActivity, {
+        const pLesserBlackBackedGull = await PActivity.create(pLesserBlackBackedActivity, {
           transaction: t,
         });
         speciesIds.LesserBlackBackedGullId = lesserBlackBackedGull.id;
-        permittedSpeciesIds.LesserBlackBackedGullId = permittedLesserBlackBackedGull.id;
+        pSpeciesIds.LesserBlackBackedGullId = pLesserBlackBackedGull.id;
       }
 
       // Set the species foreign keys in the DB.
       const newSpecies = await Species.create(speciesIds, {transaction: t});
-      const newPermittedSpecies = await PermittedSpecies.create(permittedSpeciesIds, {transaction: t});
+      const newPSpecies = await PSpecies.create(pSpeciesIds, {transaction: t});
       // Set the application's foreign keys.
       incomingApplication.LicenceHolderId = newLicenceHolderContact.id;
       incomingApplication.LicenceApplicantId = newOnBehalfContact ? newOnBehalfContact.id : newLicenceHolderContact.id;
       incomingApplication.LicenceHolderAddressId = newAddress.id;
       incomingApplication.SiteAddressId = newSiteAddress ? newSiteAddress.id : newAddress.id;
       incomingApplication.SpeciesId = newSpecies.id;
-      incomingApplication.PermittedSpeciesId = newPermittedSpecies.id;
+      incomingApplication.PermittedSpeciesId = newPSpecies.id;
 
       let newId; // The prospective random ID of the new application.
       let existingApplication; // Possible already assigned application.
@@ -733,56 +733,56 @@ const ApplicationController = {
         await Species.destroy({where: {id: species.id}, transaction: t});
 
         // Find the permitted species record.
-        const permittedSpecies = await PermittedSpecies.findByPk(application.PermittedSpeciesId, {
+        const pSpecies = await PSpecies.findByPk(application.PermittedSpeciesId, {
           transaction: t,
           rejectOnEmpty: true,
         });
 
         // Find the permitted activities records.
-        const permittedHerringGullActivity = await PermittedActivity.findByPk(permittedSpecies.HerringGullId, {
+        const pHerringGullActivity = await PActivity.findByPk(pSpecies.HerringGullId, {
           transaction: t,
         });
-        if (permittedHerringGullActivity) {
+        if (pHerringGullActivity) {
           // Soft Delete any PermittedActivity attached to the application/license.
-          await PermittedActivity.destroy({where: {id: permittedHerringGullActivity.id}, transaction: t});
+          await PActivity.destroy({where: {id: pHerringGullActivity.id}, transaction: t});
         }
 
-        const permittedBlackHeadedGullActivity = await PermittedActivity.findByPk(permittedSpecies.BlackHeadedGullId, {
+        const pBlackHeadedGullActivity = await PActivity.findByPk(pSpecies.BlackHeadedGullId, {
           transaction: t,
         });
-        if (permittedBlackHeadedGullActivity) {
+        if (pBlackHeadedGullActivity) {
           // Soft Delete any PermittedActivity attached to the application/license.
-          await PermittedActivity.destroy({where: {id: permittedBlackHeadedGullActivity.id}, transaction: t});
+          await PActivity.destroy({where: {id: pBlackHeadedGullActivity.id}, transaction: t});
         }
 
-        const permittedCommonGullActivity = await PermittedActivity.findByPk(permittedSpecies.CommonGullId, {
+        const pCommonGullActivity = await PActivity.findByPk(pSpecies.CommonGullId, {
           transaction: t,
         });
-        if (permittedCommonGullActivity) {
+        if (pCommonGullActivity) {
           // Soft Delete any PermittedActivity attached to the application/license.
-          await PermittedActivity.destroy({where: {id: permittedCommonGullActivity.id}, transaction: t});
+          await PActivity.destroy({where: {id: pCommonGullActivity.id}, transaction: t});
         }
 
-        const permittedGreatBlackBackedGullActivity = await PermittedActivity.findByPk(
-          permittedSpecies.GreatBlackBackedGullId,
+        const pGreatBlackBackedGullActivity = await PActivity.findByPk(
+          pSpecies.GreatBlackBackedGullId,
           {transaction: t},
         );
-        if (permittedGreatBlackBackedGullActivity) {
+        if (pGreatBlackBackedGullActivity) {
           // Soft Delete any PermittedActivity attached to the application/license.
-          await PermittedActivity.destroy({where: {id: permittedGreatBlackBackedGullActivity.id}, transaction: t});
+          await PActivity.destroy({where: {id: pGreatBlackBackedGullActivity.id}, transaction: t});
         }
 
-        const permittedLesserBlackBackedGullActivity = await PermittedActivity.findByPk(
-          permittedSpecies.LesserBlackBackedGullId,
+        const pLesserBlackBackedGullActivity = await PActivity.findByPk(
+          pSpecies.LesserBlackBackedGullId,
           {transaction: t},
         );
-        if (permittedLesserBlackBackedGullActivity) {
+        if (pLesserBlackBackedGullActivity) {
           // Soft Delete any PermittedActivity attached to the application/license.
-          await PermittedActivity.destroy({where: {id: permittedLesserBlackBackedGullActivity.id}, transaction: t});
+          await PActivity.destroy({where: {id: pLesserBlackBackedGullActivity.id}, transaction: t});
         }
 
         // Soft Delete any Permitted species record attached to the application/license.
-        await PermittedSpecies.destroy({where: {id: permittedSpecies.id}, transaction: t});
+        await PSpecies.destroy({where: {id: pSpecies.id}, transaction: t});
 
         // Soft Delete any Contact attached to the application/license.
         await Contact.destroy({where: {id: application.LicenceHolderId}, transaction: t});
@@ -831,7 +831,7 @@ const ApplicationController = {
         // Find the species record.
         const species = await Species.findByPk(application.SpeciesId, {transaction: t, rejectOnEmpty: true});
         // Find the permitted species record.
-        const permittedSpecies = await PermittedSpecies.findByPk(application.PermittedSpeciesId, {
+        const pSpecies = await PSpecies.findByPk(application.PermittedSpeciesId, {
           transaction: t,
           rejectOnEmpty: true,
         });
@@ -860,7 +860,7 @@ const ApplicationController = {
         // Delete any species record attached to the application/license.
         await Species.destroy({where: {id: species.id}, force: true, transaction: t});
         // Delete any PermittedSpecies record attached to the application/license.
-        await PermittedSpecies.destroy({where: {id: permittedSpecies.id}, force: true, transaction: t});
+        await PSpecies.destroy({where: {id: pSpecies.id}, force: true, transaction: t});
 
         // Find the activities records.
         const herringGullActivity = await Activity.findByPk(species.HerringGullId, {transaction: t});
@@ -896,55 +896,55 @@ const ApplicationController = {
         }
 
         // Find the permitted activities records.
-        const permittedHerringGullActivity = await PermittedActivity.findByPk(permittedSpecies.HerringGullId, {
+        const pHerringGullActivity = await PActivity.findByPk(pSpecies.HerringGullId, {
           transaction: t,
         });
-        if (permittedHerringGullActivity) {
+        if (pHerringGullActivity) {
           // Delete any PermittedActivity record attached to the application/license.
-          await PermittedActivity.destroy({where: {id: permittedHerringGullActivity.id}, force: true, transaction: t});
+          await PActivity.destroy({where: {id: pHerringGullActivity.id}, force: true, transaction: t});
         }
 
-        const permittedBlackHeadedGullActivity = await PermittedActivity.findByPk(permittedSpecies.BlackHeadedGullId, {
+        const pBlackHeadedGullActivity = await PActivity.findByPk(pSpecies.BlackHeadedGullId, {
           transaction: t,
         });
-        if (permittedBlackHeadedGullActivity) {
+        if (pBlackHeadedGullActivity) {
           // Delete any PermittedActivity record attached to the application/license.
-          await PermittedActivity.destroy({
-            where: {id: permittedBlackHeadedGullActivity.id},
+          await PActivity.destroy({
+            where: {id: pBlackHeadedGullActivity.id},
             force: true,
             transaction: t,
           });
         }
 
-        const permittedCommonGullActivity = await PermittedActivity.findByPk(permittedSpecies.CommonGullId, {
+        const pCommonGullActivity = await PActivity.findByPk(pSpecies.CommonGullId, {
           transaction: t,
         });
-        if (permittedCommonGullActivity) {
+        if (pCommonGullActivity) {
           // Delete any PermittedActivity record attached to the application/license.
-          await PermittedActivity.destroy({where: {id: permittedCommonGullActivity.id}, force: true, transaction: t});
+          await PActivity.destroy({where: {id: pCommonGullActivity.id}, force: true, transaction: t});
         }
 
-        const permittedGreatBlackBackedGullActivity = await PermittedActivity.findByPk(
-          permittedSpecies.GreatBlackBackedGullId,
+        const pGreatBlackBackedGullActivity = await PActivity.findByPk(
+          pSpecies.GreatBlackBackedGullId,
           {transaction: t},
         );
-        if (permittedGreatBlackBackedGullActivity) {
+        if (pGreatBlackBackedGullActivity) {
           // Delete any PermittedActivity record attached to the application/license.
-          await PermittedActivity.destroy({
-            where: {id: permittedGreatBlackBackedGullActivity.id},
+          await PActivity.destroy({
+            where: {id: pGreatBlackBackedGullActivity.id},
             force: true,
             transaction: t,
           });
         }
 
-        const permittedLesserBlackBackedGullActivity = await PermittedActivity.findByPk(
-          permittedSpecies.LesserBlackBackedGullId,
+        const pLesserBlackBackedGullActivity = await PActivity.findByPk(
+          pSpecies.LesserBlackBackedGullId,
           {transaction: t},
         );
-        if (permittedLesserBlackBackedGullActivity) {
+        if (pLesserBlackBackedGullActivity) {
           // Delete any PermittedActivity record attached to the application/license.
-          await PermittedActivity.destroy({
-            where: {id: permittedLesserBlackBackedGullActivity.id},
+          await PActivity.destroy({
+            where: {id: pLesserBlackBackedGullActivity.id},
             force: true,
             transaction: t,
           });

--- a/src/controllers/license.ts
+++ b/src/controllers/license.ts
@@ -46,7 +46,7 @@ const setLicenceNotificationDetails = (application: any, licence: any) => {
       : 'No address line 2',
     addressTown: application.LicenceHolderAddress.addressTown,
     postcode: application.LicenceHolderAddress.postcode,
-    permittedSpeciesActivitiesList: createPermittedSpeciesActivitiesList(application.PermittedSpecies),
+    permittedSpeciesActivitiesList: createPermittedSpeciesActivitiesList(application.PSpecies),
     identifiedSpecies: createIdentifiedSpecies(application.Species),
     issuesList: createIssues(application.ApplicationIssue),
     measuresTried: createMeasures(application.ApplicationMeasure, 'Tried'),
@@ -122,23 +122,23 @@ const displayableRanges = (range: string | undefined): string => {
 const createPermittedSpeciesActivitiesList = (species: any): string => {
   const permittedActivities = [];
   if (species.HerringGullId) {
-    permittedActivities.push(addActivities(species.PermittedHerringGull, 'Herring gull'));
+    permittedActivities.push(addActivities(species.PHerringGull, 'Herring gull'));
   }
 
   if (species.BlackHeadedGullId) {
-    permittedActivities.push(addActivities(species.PermittedBlackHeadedGull, 'Black-headed gull'));
+    permittedActivities.push(addActivities(species.PBlackHeadedGull, 'Black-headed gull'));
   }
 
   if (species.CommonGullId) {
-    permittedActivities.push(addActivities(species.PermittedCommonGull, 'Common gull'));
+    permittedActivities.push(addActivities(species.PCommonGull, 'Common gull'));
   }
 
   if (species.GreatBlackBackedGullId) {
-    permittedActivities.push(addActivities(species.PermittedGreatBlackBackedGull, 'Great black-backed gull'));
+    permittedActivities.push(addActivities(species.PGreatBlackBackedGull, 'Great black-backed gull'));
   }
 
   if (species.LesserBlackBackedGullId) {
-    permittedActivities.push(addActivities(species.PermittedLesserBlackBackedGull, 'Lesser black-backed gull'));
+    permittedActivities.push(addActivities(species.PLesserBlackBackedGull, 'Lesser black-backed gull'));
   }
 
   return permittedActivities.join('\n');

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -9,8 +9,8 @@ import Issue from './issue';
 import Measure from './measure';
 import Species from './species';
 import Activity from './activity';
-import PermittedSpecies from './permitted-species';
-import PermittedActivity from './permitted-activity';
+import PSpecies from './p-species';
+import PActivity from './p-activity';
 import License from './license';
 import LicenseAdvisory from './license-advisory';
 import LicenseCondition from './license-condition';
@@ -40,8 +40,8 @@ const database = {
   Measure: Measure(sequelize),
   Species: Species(sequelize),
   Activity: Activity(sequelize),
-  PermittedSpecies: PermittedSpecies(sequelize),
-  PermittedActivity: PermittedActivity(sequelize),
+  PSpecies: PSpecies(sequelize),
+  PActivity: PActivity(sequelize),
   License: License(sequelize),
   LicenseAdvisory: LicenseAdvisory(sequelize),
   LicenseCondition: LicenseCondition(sequelize),
@@ -58,14 +58,14 @@ database.Application.belongsTo(database.Contact, {as: 'LicenceApplicant', foreig
 database.Application.belongsTo(database.Address, {as: 'LicenceHolderAddress', foreignKey: 'LicenceHolderAddressId'});
 database.Application.belongsTo(database.Address, {as: 'SiteAddress', foreignKey: 'SiteAddressId'});
 database.Application.belongsTo(database.Species, {as: 'Species', foreignKey: 'SpeciesId'});
-database.Application.belongsTo(database.PermittedSpecies, {as: 'PermittedSpecies', foreignKey: 'PermittedSpeciesId'});
+database.Application.belongsTo(database.PSpecies, {as: 'PSpecies', foreignKey: 'PermittedSpeciesId'});
 
 database.Contact.hasOne(database.Application, {as: 'LicenceHolder', foreignKey: 'LicenceHolderId'});
 database.Contact.hasOne(database.Application, {as: 'LicenceApplicant', foreignKey: 'LicenceApplicantId'});
 database.Address.hasOne(database.Application, {as: 'LicenceHolderAddress', foreignKey: 'LicenceHolderAddressId'});
 database.Address.hasOne(database.Application, {as: 'SiteAddress', foreignKey: 'SiteAddressId'});
 database.Species.hasOne(database.Application, {as: 'Species', foreignKey: 'SpeciesId'});
-database.PermittedSpecies.hasOne(database.Application, {as: 'PermittedSpecies', foreignKey: 'PermittedSpeciesId'});
+database.PSpecies.hasOne(database.Application, {as: 'PSpecies', foreignKey: 'PermittedSpeciesId'});
 
 database.Assessment.belongsTo(database.Application, {as: 'ApplicationAssessment', foreignKey: 'ApplicationId'});
 database.License.belongsTo(database.Application, {as: 'License', foreignKey: 'ApplicationId'});
@@ -107,39 +107,39 @@ database.Activity.hasOne(database.Species, {as: 'CommonGull', foreignKey: 'Commo
 database.Activity.hasOne(database.Species, {as: 'GreatBlackBackedGull', foreignKey: 'GreatBlackBackedGullId'});
 database.Activity.hasOne(database.Species, {as: 'LesserBlackBackedGull', foreignKey: 'LesserBlackBackedGullId'});
 
-database.PermittedSpecies.belongsTo(database.PermittedActivity, {
-  as: 'PermittedHerringGull',
+database.PSpecies.belongsTo(database.PActivity, {
+  as: 'PHerringGull',
   foreignKey: 'HerringGullId',
 });
-database.PermittedSpecies.belongsTo(database.PermittedActivity, {
-  as: 'PermittedBlackHeadedGull',
+database.PSpecies.belongsTo(database.PActivity, {
+  as: 'PBlackHeadedGull',
   foreignKey: 'BlackHeadedGullId',
 });
-database.PermittedSpecies.belongsTo(database.PermittedActivity, {
-  as: 'PermittedCommonGull',
+database.PSpecies.belongsTo(database.PActivity, {
+  as: 'PCommonGull',
   foreignKey: 'CommonGullId',
 });
-database.PermittedSpecies.belongsTo(database.PermittedActivity, {
-  as: 'PermittedGreatBlackBackedGull',
+database.PSpecies.belongsTo(database.PActivity, {
+  as: 'PGreatBlackBackedGull',
   foreignKey: 'GreatBlackBackedGullId',
 });
-database.PermittedSpecies.belongsTo(database.PermittedActivity, {
-  as: 'PermittedLesserBlackBackedGull',
+database.PSpecies.belongsTo(database.PActivity, {
+  as: 'PLesserBlackBackedGull',
   foreignKey: 'LesserBlackBackedGullId',
 });
 
-database.PermittedActivity.hasOne(database.PermittedSpecies, {as: 'PermittedHerringGull', foreignKey: 'HerringGullId'});
-database.PermittedActivity.hasOne(database.PermittedSpecies, {
-  as: 'PermittedBlackHeadedGull',
+database.PActivity.hasOne(database.PSpecies, {as: 'PHerringGull', foreignKey: 'HerringGullId'});
+database.PActivity.hasOne(database.PSpecies, {
+  as: 'PBlackHeadedGull',
   foreignKey: 'BlackHeadedGullId',
 });
-database.PermittedActivity.hasOne(database.PermittedSpecies, {as: 'PermittedCommonGull', foreignKey: 'CommonGullId'});
-database.PermittedActivity.hasOne(database.PermittedSpecies, {
-  as: 'PermittedGreatBlackBackedGull',
+database.PActivity.hasOne(database.PSpecies, {as: 'PCommonGull', foreignKey: 'CommonGullId'});
+database.PActivity.hasOne(database.PSpecies, {
+  as: 'PGreatBlackBackedGull',
   foreignKey: 'GreatBlackBackedGullId',
 });
-database.PermittedActivity.hasOne(database.PermittedSpecies, {
-  as: 'PermittedLesserBlackBackedGull',
+database.PActivity.hasOne(database.PSpecies, {
+  as: 'PLesserBlackBackedGull',
   foreignKey: 'LesserBlackBackedGullId',
 });
 

--- a/src/models/p-activity.ts
+++ b/src/models/p-activity.ts
@@ -6,8 +6,8 @@ import {DataTypes, Model, Sequelize} from 'sequelize';
  * @param {Sequelize.Sequelize} sequelize A Sequelize connection.
  * @returns {Sequelize.Model} An Permitted Activity model.
  */
-const PermittedActivityModel = (sequelize: Sequelize) => {
-  class PermittedActivity extends Model {
+const PActivityModel = (sequelize: Sequelize) => {
+  class PActivity extends Model {
     public id!: number;
     public removeNests!: boolean;
     public quantityNestsToRemove!: string;
@@ -23,7 +23,7 @@ const PermittedActivityModel = (sequelize: Sequelize) => {
     public quantityAdultsToKill!: number;
   }
 
-  PermittedActivity.init(
+  PActivity.init(
     {
       removeNests: {
         type: DataTypes.BOOLEAN,
@@ -64,13 +64,13 @@ const PermittedActivityModel = (sequelize: Sequelize) => {
     },
     {
       sequelize,
-      modelName: 'PermittedActivity',
+      modelName: 'PActivity',
       timestamps: true,
       paranoid: true,
     },
   );
 
-  return PermittedActivity;
+  return PActivity;
 };
 
-export {PermittedActivityModel as default};
+export {PActivityModel as default};

--- a/src/models/p-species.ts
+++ b/src/models/p-species.ts
@@ -6,8 +6,8 @@ import {DataTypes, Model, Sequelize} from 'sequelize';
  * @param {Sequelize.Sequelize} sequelize A Sequelize connection.
  * @returns {Sequelize.Model} A Permitted Species model.
  */
-const PermittedSpeciesModel = (sequelize: Sequelize) => {
-  class PermittedSpecies extends Model {
+const PSpeciesModel = (sequelize: Sequelize) => {
+  class PSpecies extends Model {
     public id!: number;
     public HerringGullId!: number;
     public BlackHeadedGullId!: number;
@@ -16,7 +16,7 @@ const PermittedSpeciesModel = (sequelize: Sequelize) => {
     public LesserBlackBackedGullId!: number;
   }
 
-  PermittedSpecies.init(
+  PSpecies.init(
     {
       HerringGullId: {
         type: DataTypes.INTEGER,
@@ -36,13 +36,13 @@ const PermittedSpeciesModel = (sequelize: Sequelize) => {
     },
     {
       sequelize,
-      modelName: 'PermittedSpecies',
+      modelName: 'PSpecies',
       timestamps: true,
       paranoid: true,
     },
   );
 
-  return PermittedSpecies;
+  return PSpecies;
 };
 
-export {PermittedSpeciesModel as default};
+export {PSpeciesModel as default};

--- a/util/db/migrations/20220217112641-rename-permitted-species-activity-table-names.js
+++ b/util/db/migrations/20220217112641-rename-permitted-species-activity-table-names.js
@@ -1,40 +1,40 @@
 /* eslint-disable unicorn/prefer-module */
 const databaseConfig = require('../database.js');
 
-  module.exports = {
-    up: async (queryInterface, Sequelize) => {
-      await queryInterface.renameTable(
-        {
-          schema: databaseConfig.database.schema,
-          tableName: 'PermittedActivities',
-        },
-        'PActivities'
-      );
+module.exports = {
+  up: async (queryInterface) => {
+    await queryInterface.renameTable(
+      {
+        schema: databaseConfig.database.schema,
+        tableName: 'PermittedActivities',
+      },
+      'PActivities',
+    );
 
-      await queryInterface.renameTable(
-        {
-          schema: databaseConfig.database.schema,
-          tableName: 'PermittedSpecies',
-        },
-        'PSpecies'
-      );
-    },
+    await queryInterface.renameTable(
+      {
+        schema: databaseConfig.database.schema,
+        tableName: 'PermittedSpecies',
+      },
+      'PSpecies',
+    );
+  },
 
-    down: async (queryInterface, Sequelize) => {
-      await queryInterface.renameTable(
-        {
-          schema: databaseConfig.database.schema,
-          tableName: 'PSpecies',
-        },
-        'PermittedSpecies'
-      );
+  down: async (queryInterface) => {
+    await queryInterface.renameTable(
+      {
+        schema: databaseConfig.database.schema,
+        tableName: 'PSpecies',
+      },
+      'PermittedSpecies',
+    );
 
-      await queryInterface.renameTable(
-        {
-          schema: databaseConfig.database.schema,
-          tableName: 'PActivities',
-        },
-        'PermittedActivities'
-      );
-    }
-  };
+    await queryInterface.renameTable(
+      {
+        schema: databaseConfig.database.schema,
+        tableName: 'PActivities',
+      },
+      'PermittedActivities',
+    );
+  },
+};

--- a/util/db/migrations/20220217112641-rename-permitted-species-activity-table-names.js
+++ b/util/db/migrations/20220217112641-rename-permitted-species-activity-table-names.js
@@ -1,0 +1,40 @@
+/* eslint-disable unicorn/prefer-module */
+const databaseConfig = require('../database.js');
+
+  module.exports = {
+    up: async (queryInterface, Sequelize) => {
+      await queryInterface.renameTable(
+        {
+          schema: databaseConfig.database.schema,
+          tableName: 'PermittedActivities',
+        },
+        'PActivities'
+      );
+
+      await queryInterface.renameTable(
+        {
+          schema: databaseConfig.database.schema,
+          tableName: 'PermittedSpecies',
+        },
+        'PSpecies'
+      );
+    },
+
+    down: async (queryInterface, Sequelize) => {
+      await queryInterface.renameTable(
+        {
+          schema: databaseConfig.database.schema,
+          tableName: 'PSpecies',
+        },
+        'PermittedSpecies'
+      );
+
+      await queryInterface.renameTable(
+        {
+          schema: databaseConfig.database.schema,
+          tableName: 'PActivities',
+        },
+        'PermittedActivities'
+      );
+    }
+  };


### PR DESCRIPTION
Renames the `PermittedSpecies` and `PermittedActivities` tables and updates the API to deal with the change.

Required as PostgreSQL has a 63 byte limit on object references that our use of Sequelize breakes with long table / column / object names.

Also updates to email personalisation objects to match their associated Notify templates.