### PR TITLE
Change the way site address is created. Issue Licensing 1130

### DIFF
--- a/src/controllers/application.ts
+++ b/src/controllers/application.ts
@@ -125,10 +125,7 @@ const setHolderApplicantConfirmEmailDetails = (
     lhName: licenceHolderContact.name,
     laName: onBehalfContact.name,
     applicationDate: createDisplayDate(new Date(createdAt)),
-    siteAddressLine1: siteAddress.addressLine1,
-    siteAddressLine2: siteAddress.addressLine2,
-    siteAddressTown: siteAddress.addressTown,
-    sitePostcode: siteAddress.postcode,
+    siteAddress: createSummaryAddress(siteAddress),
     id,
   };
 };


### PR DESCRIPTION
Issue https://github.com/Scottish-Natural-Heritage/Licensing/issues/1130

Needs a change made to the notify template `b227af1f-4709-4be5-a111-66605dcf0525` changing all references to the site address values to a single `siteAddress` value.