### PR TITLE
Add GULLS_HOST_PREFIX env var and use it in magic link creation

### DIFF
--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -8,6 +8,7 @@ interface AppConfig {
   roGullsPassword: string;
   underTest: boolean;
   notifyApiKey: string | null;
+  hostPrefix: string;
 }
 
 const config: AppConfig = {
@@ -20,6 +21,7 @@ const config: AppConfig = {
   roGullsPassword: process.env.RO_GULLS_DB_PASS ?? 'override_this_value',
   underTest: Boolean(process.env.UNDER_TEST),
   notifyApiKey: process.env.GULLS_NOTIFY_API_KEY ?? null,
+  hostPrefix: process.env.GULLS_HOST_PREFIX ?? 'http://localhost:3016'
 };
 
 export default config;

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -21,7 +21,7 @@ const config: AppConfig = {
   roGullsPassword: process.env.RO_GULLS_DB_PASS ?? 'override_this_value',
   underTest: Boolean(process.env.UNDER_TEST),
   notifyApiKey: process.env.GULLS_NOTIFY_API_KEY ?? null,
-  hostPrefix: process.env.GULLS_HOST_PREFIX ?? 'http://localhost:3016'
+  hostPrefix: process.env.GULLS_HOST_PREFIX ?? 'http://localhost:3016',
 };
 
 export default config;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -456,9 +456,7 @@ const routes: ServerRoute[] = [
         );
 
         // Create the confirm magic link base URL.
-        const confirmBaseUrl = `${request.url.protocol}//${request.url.hostname}${String(
-          request.query.onBehalfApprovePath,
-        )}`;
+        const confirmBaseUrl = `${config.hostPrefix}${String(request.query.onBehalfApprovePath)}`;
 
         // Check there's actually one there, otherwise we'll have to make one up.
         const urlInvalid = confirmBaseUrl === undefined || confirmBaseUrl === null;


### PR DESCRIPTION
Issue https://github.com/Scottish-Natural-Heritage/Licensing/issues/1140.

The API needs access to the GULLS_HOST_PREFIX to correctly create the magic links used in the 14 day reminder emails.