### PR TITLE
Feature/twenty one day withdrawal cron job

### DIFF
--- a/src/controllers/scheduled.ts
+++ b/src/controllers/scheduled.ts
@@ -78,10 +78,10 @@ const sendReminderEmailForApplicant = async (emailDetails: any, emailAddress: an
  * @param {any} emailDetails The details to use in the email to be sent.
  * @param {any} emailAddress The email address to send the email to.
  */
- const sendWithdrawHolderEmail = async (emailDetails: any, emailAddress: any) => {
+const sendWithdrawHolderEmail = async (emailDetails: any, emailAddress: any) => {
   if (config.notifyApiKey) {
     const notifyClient = new NotifyClient(config.notifyApiKey);
-    await notifyClient.sendEmail('d2dfaf64-49fb-4383-9713-33aa55898afa ', emailAddress, {
+    await notifyClient.sendEmail('d2dfaf64-49fb-4383-9713-33aa55898afa', emailAddress, {
       personalisation: emailDetails,
       emailReplyToId: '4b49467e-2a35-4713-9d92-809c55bf1cdd',
     });
@@ -95,10 +95,10 @@ const sendReminderEmailForApplicant = async (emailDetails: any, emailAddress: an
  * @param {any} emailDetails The details to use in the email to be sent.
  * @param {any} emailAddress The email address to send the email to.
  */
- const sendWithdrawApplicantEmail = async (emailDetails: any, emailAddress: any) => {
+const sendWithdrawApplicantEmail = async (emailDetails: any, emailAddress: any) => {
   if (config.notifyApiKey) {
     const notifyClient = new NotifyClient(config.notifyApiKey);
-    await notifyClient.sendEmail('d2dfaf64-49fb-4383-9713-33aa55898afa ', emailAddress, {
+    await notifyClient.sendEmail('d2dfaf64-49fb-4383-9713-33aa55898afa', emailAddress, {
       personalisation: emailDetails,
       emailReplyToId: '4b49467e-2a35-4713-9d92-809c55bf1cdd',
     });
@@ -189,6 +189,30 @@ const ScheduledController = {
   getUnconfirmed: async () => {
     return Application.findAll({
       where: {confirmedByLicenseHolder: false, fourteenDayReminder: false || null},
+      include: [
+        {
+          model: Contact,
+          as: 'LicenceHolder',
+        },
+        {
+          model: Contact,
+          as: 'LicenceApplicant',
+        },
+        {
+          model: Address,
+          as: 'LicenceHolderAddress',
+        },
+        {
+          model: Address,
+          as: 'SiteAddress',
+        },
+      ],
+    });
+  },
+
+  getUnconfirmedReminded: async () => {
+    return Application.findAll({
+      where: {confirmedByLicenseHolder: false, fourteenDayReminder: true},
       include: [
         {
           model: Contact,

--- a/src/controllers/scheduled.ts
+++ b/src/controllers/scheduled.ts
@@ -253,14 +253,13 @@ const ScheduledController = {
   checkUnconfirmedAndWithdraw: async (unconfirmed: any) => {
     const todayDateMinusTwentyOneDays: Date = new Date(new Date().setDate(new Date().getDate() - 21));
 
-    // Filter any unconfirmed applications to only include those that are 14 days old or older.
+    // Filter any unconfirmed applications to only include those that are 21 days old or older.
     unconfirmed = unconfirmed.filter((application: any) => {
       return new Date(application.createdAt) <= todayDateMinusTwentyOneDays;
     });
 
     for (const application of unconfirmed) {
-      // Loop through each application and create personalisation object, the await needs to be part of the loop.
-      // eslint-disable-next-line no-await-in-loop
+      // Loop through each application and create personalisation object.
       const emailDetails = set21DayWithdrawEmailDetails(
         application.id,
         application.createdAt,

--- a/src/controllers/scheduled.ts
+++ b/src/controllers/scheduled.ts
@@ -72,30 +72,12 @@ const sendReminderEmailForApplicant = async (emailDetails: any, emailAddress: an
 };
 
 /**
- * This function calls the Notify API and asks for a 21 day withdraw email to be sent to
- * the proposed licence holder.
+ * This function calls the Notify API and asks for a 21 day withdraw email to be sent.
  *
  * @param {any} emailDetails The details to use in the email to be sent.
  * @param {any} emailAddress The email address to send the email to.
  */
-const sendWithdrawHolderEmail = async (emailDetails: any, emailAddress: any) => {
-  if (config.notifyApiKey) {
-    const notifyClient = new NotifyClient(config.notifyApiKey);
-    await notifyClient.sendEmail('d2dfaf64-49fb-4383-9713-33aa55898afa', emailAddress, {
-      personalisation: emailDetails,
-      emailReplyToId: '4b49467e-2a35-4713-9d92-809c55bf1cdd',
-    });
-  }
-};
-
-/**
- * This function calls the Notify API and asks for a 21 day withdraw email to be sent to
- * the licence applicant.
- *
- * @param {any} emailDetails The details to use in the email to be sent.
- * @param {any} emailAddress The email address to send the email to.
- */
-const sendWithdrawApplicantEmail = async (emailDetails: any, emailAddress: any) => {
+const sendWithdrawEmail = async (emailDetails: any, emailAddress: any) => {
   if (config.notifyApiKey) {
     const notifyClient = new NotifyClient(config.notifyApiKey);
     await notifyClient.sendEmail('d2dfaf64-49fb-4383-9713-33aa55898afa', emailAddress, {
@@ -294,8 +276,8 @@ const ScheduledController = {
 
       // Send the withdraw emails, the awaits needs to be part of the loop.
       /* eslint-disable no-await-in-loop */
-      await sendWithdrawHolderEmail(emailDetails, application.LicenceHolder.emailAddress);
-      await sendWithdrawApplicantEmail(emailDetails, application.LicenceApplicant.emailAddress);
+      await sendWithdrawEmail(emailDetails, application.LicenceHolder.emailAddress);
+      await sendWithdrawEmail(emailDetails, application.LicenceApplicant.emailAddress);
       /* eslint-enable no-await-in-loop */
     }
 

--- a/src/controllers/scheduled.ts
+++ b/src/controllers/scheduled.ts
@@ -292,7 +292,7 @@ const ScheduledController = {
         application.SiteAddress,
       );
 
-      // Send the reminder emails, the awaits needs to be part of the loop.
+      // Send the withdraw emails, the awaits needs to be part of the loop.
       /* eslint-disable no-await-in-loop */
       await sendWithdrawHolderEmail(emailDetails, application.LicenceHolder.emailAddress);
       await sendWithdrawApplicantEmail(emailDetails, application.LicenceApplicant.emailAddress);

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -538,6 +538,26 @@ const routes: ServerRoute[] = [
     },
   },
 
+  {
+    method: 'delete',
+    path: `${config.pathPrefix}/withdrawal`,
+    handler: async (request: Request, h: ResponseToolkit) => {
+      try {
+        // Try to get any unconfirmed applications.
+        const applications = await Scheduled.getUnconfirmed();
+
+        const unconfirmed: any = await Scheduled.checkUnconfirmedAndWithdraw(applications);
+
+        return h.response().code(200);
+      } catch (error: unknown) {
+        // Log any error.
+        request.logger.error(JsonUtils.unErrorJson(error));
+        // Something bad happened? Return 500 and the error.
+        return h.response({error}).code(500);
+      }
+    },
+  },
+
   /**
    * Soft DELETEs a single licence and all child records (revoke).
    */

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -557,7 +557,8 @@ const routes: ServerRoute[] = [
             reason: 'Application unconfirmed after 21 days.',
             createdBy: 'node-cron automated process',
           };
-
+          // Disabled as we need to loop through the list of applications to withdraw.
+          // eslint-disable-next-line no-await-in-loop
           await Application.withdraw(application.id, withdrawalReason);
         }
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -543,8 +543,8 @@ const routes: ServerRoute[] = [
     path: `${config.pathPrefix}/withdrawal`,
     handler: async (request: Request, h: ResponseToolkit) => {
       try {
-        // Try to get any unconfirmed applications.
-        const applications = await Scheduled.getUnconfirmed();
+        // Try to get any unconfirmed but reminded applications.
+        const applications = await Scheduled.getUnconfirmedReminded();
 
         const unconfirmed: any = await Scheduled.checkUnconfirmedAndWithdraw(applications);
 
@@ -555,6 +555,7 @@ const routes: ServerRoute[] = [
 
         for (const application of unconfirmed) {
           const withdrawalReason = {
+            ApplicationId: application.id,
             reason: 'Application unconfirmed after 21 days.',
             createdBy: 'node-cron automated process',
           };
@@ -562,6 +563,7 @@ const routes: ServerRoute[] = [
           await Application.withdraw(application.id, withdrawalReason);
         }
 
+        // Return something here.
         return h.response().code(200);
       } catch (error: unknown) {
         // Log any error.

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,7 +17,7 @@ import config from './config/app';
 import JsonUtils from './json-utils';
 
 // Cron scheduled tasks, set to trigger at 6am each day.
-cron.schedule('* * * * *', async () => {
+cron.schedule('0 6 * * *', async () => {
   console.log('Triggering cron job(s).');
 
   // Check for unconfirmed applications and sent out 14 day reminder emails.

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,7 +17,7 @@ import config from './config/app';
 import JsonUtils from './json-utils';
 
 // Cron scheduled tasks, set to trigger at 6am each day.
-cron.schedule('0 6 * * *', async () => {
+cron.schedule('* * * * *', async () => {
   console.log('Triggering cron job(s).');
 
   // Check for unconfirmed applications and sent out 14 day reminder emails.

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,21 +16,29 @@ import routes from './routes';
 import config from './config/app';
 import JsonUtils from './json-utils';
 
-// Cron scheduled task, set to trigger at 6am each day and send out 14 day reminder emails.
+// Cron scheduled tasks, set to trigger at 6am each day.
 cron.schedule('0 6 * * *', async () => {
   console.log('Triggering cron job(s).');
+
+  // Check for unconfirmed applications and sent out 14 day reminder emails.
   try {
-    const response = await axios.patch(`http://localhost:3017${config.pathPrefix}/reminder`, undefined, {
+    await axios.patch(`http://localhost:3017${config.pathPrefix}/reminder`, undefined, {
       params: {
         onBehalfApprovePath: '/gulls-health-and-safety/on-behalf-approve?token=',
       },
     });
-    console.log('Ending cron job(s).');
-    return response;
   } catch (error: unknown) {
     console.error(JsonUtils.unErrorJson(error));
-    return undefined;
   }
+
+  // Check for unconfirmed after 21 days applications and send out withdrawn emails.
+  try {
+    await axios.delete(`http://localhost:3017${config.pathPrefix}/withdrawal`);
+  } catch (error: unknown) {
+    console.error(JsonUtils.unErrorJson(error));
+  }
+
+  console.log('Ending cron job(s).');
 });
 
 // Start up our micro-app.


### PR DESCRIPTION
Adds a `node-cron` job that checks for unconfirmed and 21 days or older applications and withdraws them, sending a notification to holder and applicant.

Issue https://github.com/Scottish-Natural-Heritage/Licensing/issues/967