### PR TITLE
Add paranoid false to application findOne function to allow revoked

### DIFF
--- a/src/controllers/application.ts
+++ b/src/controllers/application.ts
@@ -295,70 +295,86 @@ const ApplicationController = {
         {
           model: Species,
           as: 'Species',
+          paranoid: false,
           include: [
             {
               model: Activity,
               as: 'HerringGull',
+              paranoid: false,
             },
             {
               model: Activity,
               as: 'BlackHeadedGull',
+              paranoid: false,
             },
             {
               model: Activity,
               as: 'CommonGull',
+              paranoid: false,
             },
             {
               model: Activity,
               as: 'GreatBlackBackedGull',
+              paranoid: false,
             },
             {
               model: Activity,
               as: 'LesserBlackBackedGull',
+              paranoid: false,
             },
           ],
         },
         {
           model: PSpecies,
           as: 'PSpecies',
+          paranoid: false,
           include: [
             {
               model: PActivity,
               as: 'PHerringGull',
+              paranoid: false,
             },
             {
               model: PActivity,
               as: 'PBlackHeadedGull',
+              paranoid: false,
             },
             {
               model: PActivity,
               as: 'PCommonGull',
+              paranoid: false,
             },
             {
               model: PActivity,
               as: 'PGreatBlackBackedGull',
+              paranoid: false,
             },
             {
               model: PActivity,
               as: 'PLesserBlackBackedGull',
+              paranoid: false,
             },
           ],
         },
         {
           model: Issue,
           as: 'ApplicationIssue',
+          paranoid: false,
         },
         {
           model: Measure,
           as: 'ApplicationMeasure',
+          paranoid: false,
         },
         {
           model: Assessment,
           as: 'ApplicationAssessment',
+          paranoid: false,
         },
         {
           model: Note,
           as: 'ApplicationNotes',
+          paranoid: false,
         },
         {
           model: License,
@@ -368,20 +384,24 @@ const ApplicationController = {
             {
               model: LicenseAdvisory,
               as: 'LicenseAdvisories',
+              paranoid: false,
               include: [
                 {
                   model: Advisory,
                   as: 'Advisory',
+                  paranoid: false,
                 },
               ],
             },
             {
               model: LicenseCondition,
               as: 'LicenseConditions',
+              paranoid: false,
               include: [
                 {
                   model: Condition,
                   as: 'Condition',
+                  paranoid: false,
                 },
               ],
             },


### PR DESCRIPTION
On the preview page a link to a revoked licence is broken as parts of the licence are not returned from the API due to soft delete - this PR will get the soft deleted values from the DB so the revoked licence can be viewed on the staff preview page.

Issue https://github.com/Scottish-Natural-Heritage/Licensing/issues/1100.