### PR TITLE
Add assessment model to get summarized applications endpoint

### DIFF
--- a/src/controllers/application.ts
+++ b/src/controllers/application.ts
@@ -495,6 +495,10 @@ const ApplicationController = {
           model: Withdrawal,
           as: 'Withdrawal',
         },
+        {
+          model: Assessment,
+          as: 'ApplicationAssessment',
+        },
       ],
     });
   },


### PR DESCRIPTION
Issue https://github.com/Scottish-Natural-Heritage/Licensing/issues/1058#issuecomment-1076391051

We need any application assessment to be included in the summary applications return so we can check for the refused status on the applications page of the staff application. See the comment in the issue for details.