### PR TITLE
Update check on length of licence number. Issue 1199

### DIFF
--- a/src/controllers/cleaning-functions.ts
+++ b/src/controllers/cleaning-functions.ts
@@ -454,7 +454,7 @@ const cleanAuthenticationInfo = (body: any, existingId: string): any => {
 
   // Check the licenceNumber to ensure that it is a valid licence number.
   const regExNumbersOnly = /^\d+$/;
-  const isValidLengthLicenseNumber = licenceNumber.length === 6;
+  const isValidLengthLicenseNumber = licenceNumber.length <= 6;
   const isValidNumbersLicenseNumber = regExNumbersOnly.test(licenceNumber);
 
   return {

--- a/tests/v1-gulls-health-and-safety-api.postman_collection.json
+++ b/tests/v1-gulls-health-and-safety-api.postman_collection.json
@@ -1,7 +1,7 @@
 {
 	"info": {
 		"_postman_id": "df450f75-5890-4c27-a061-a7979a06da31",
-		"name": "v1-gulls-health-and-safety-api Copy",
+		"name": "v1-gulls-health-and-safety-api",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [


### PR DESCRIPTION
Issue https://github.com/Scottish-Natural-Heritage/Licensing/issues/1199

Updates the check on the length of the licence number to allow numbers of length 6 or less.