### PR TITLE
Update validation on licence number length

### DIFF
--- a/src/controllers/application.ts
+++ b/src/controllers/application.ts
@@ -635,11 +635,11 @@ const ApplicationController = {
       let remainingAttempts = 10; // Allow 10 attempts to check if the ID is in use.
       let foundExistingId = true; // Assume true until checked.
 
-      // Generate a random 6 digit ID and check if it's already in use.
+      // Generate a random 6 digit ID between 1000 and 999_999 and checks if it's already in use.
       // No await in loop disabled because we need to wait for the result.
       /* eslint-disable no-await-in-loop */
       while (foundExistingId && remainingAttempts > 0) {
-        newId = Math.floor(Math.random() * 999_999);
+        newId = Math.floor(Math.random() * (999_999 - 1000) + 1000);
         existingApplication = await Application.findByPk(newId);
         if (!existingApplication) {
           foundExistingId = false;

--- a/src/controllers/cleaning-functions.ts
+++ b/src/controllers/cleaning-functions.ts
@@ -454,7 +454,7 @@ const cleanAuthenticationInfo = (body: any, existingId: string): any => {
 
   // Check the licenceNumber to ensure that it is a valid licence number.
   const regExNumbersOnly = /^\d+$/;
-  const isValidLengthLicenseNumber = licenceNumber.length <= 6;
+  const isValidLengthLicenseNumber = licenceNumber.length >= 4 && licenceNumber.length <= 6;
   const isValidNumbersLicenseNumber = regExNumbersOnly.test(licenceNumber);
 
   return {


### PR DESCRIPTION
Part of issue https://github.com/Scottish-Natural-Heritage/Licensing/issues/1215

Updates validation on licence number length and updates the code to generate an application id so the number is always between 1000 and 999999.