### PR TITLE
Change returns message from eggs removed to eggs destroyed. Issue 1246

### DIFF
--- a/src/controllers/returns.ts
+++ b/src/controllers/returns.ts
@@ -73,7 +73,7 @@ const addReturnActivities = (activities: any, speciesType: string): string => {
     returnActivities.push(
       `${speciesType} - ${String(activities.quantityNestsRemoved)} nests removed and ${String(
         activities.quantityEggsRemoved,
-      )} eggs removed on ${createDisplayDate(new Date(activities.dateNestsEggsRemoved))}`,
+      )} eggs destroyed on ${createDisplayDate(new Date(activities.dateNestsEggsRemoved))}`,
     );
   } else if (activities.removeNests && activities.quantityNestsRemoved) {
     returnActivities.push(


### PR DESCRIPTION
UAT feedback for https://github.com/Scottish-Natural-Heritage/Licensing/issues/1246

Changes the phrase "eggs removed" to "eggs destroyed" for egg removal when building the string used by the Notify API.