### PR TITLE
Remove errant star from string passed to notify. No issue

### DIFF
--- a/src/controllers/returns.ts
+++ b/src/controllers/returns.ts
@@ -77,7 +77,7 @@ const addReturnActivities = (activities: any, speciesType: string): string => {
     );
   } else if (activities.removeNests && activities.quantityNestsRemoved) {
     returnActivities.push(
-      `* ${speciesType} - ${String(activities.quantityNestsRemoved)} nests removed on ${createDisplayDate(
+      `${speciesType} - ${String(activities.quantityNestsRemoved)} nests removed on ${createDisplayDate(
         new Date(activities.dateNestsEggsRemoved),
       )}`,
     );


### PR DESCRIPTION
Removes an errant `*` from the string passed to notify to stop part of the list of return activities being bulleted. No issue raised.