### PR TITLE
Bugfix/use upsert for additional measures patch

### DIFF
--- a/src/controllers/assessment.ts
+++ b/src/controllers/assessment.ts
@@ -37,7 +37,7 @@ const AssessmentController = {
       // If we have additionalMeasures then we need to create a new record if not we carry on.
       if (additionalMeasures) {
         additionalMeasures.ApplicationId = applicationId;
-        await AssessmentMeasure.create(additionalMeasures, {transaction: t});
+        await AssessmentMeasure.upsert(additionalMeasures, {transaction: t});
       }
 
       // Return the upsert object.

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -905,12 +905,12 @@ const routes: ServerRoute[] = [
 
         // If we already have an assessment measure entry we need it's ID to upsert the new values,
         // so cast the application first so we can access the AssessmentMeasure object.
-        const assessmentMeasure = <any>application ? <any>application : undefined;
+        const assessmentMeasure = application as any;
 
         let assessmentMeasureId;
 
-        if (assessmentMeasure.AssessmentMeasure && incomingAdditionalMeasures) {
-          assessmentMeasureId = assessmentMeasure.AssessmentMeasure.id
+        if (assessmentMeasure?.AssessmentMeasure && incomingAdditionalMeasures) {
+          assessmentMeasureId = assessmentMeasure.AssessmentMeasure.id;
           incomingAdditionalMeasures.id = assessmentMeasureId;
         }
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -903,6 +903,17 @@ const routes: ServerRoute[] = [
 
         const incomingAdditionalMeasures = CleaningFunctions.cleanAdditionalMeasure(request.payload as any);
 
+        // If we already have an assessment measure entry we need it's ID to upsert the new values,
+        // so cast the application first so we can access the AssessmentMeasure object.
+        const assessmentMeasure = <any>application ? <any>application : undefined;
+
+        let assessmentMeasureId;
+
+        if (assessmentMeasure.AssessmentMeasure) {
+          assessmentMeasureId = assessmentMeasure.AssessmentMeasure.id
+          incomingAdditionalMeasures.id = assessmentMeasureId;
+        }
+
         // Upsert the assessment.
         const assessment = await Assessment.upsert(incomingAssessment, existingId, incomingAdditionalMeasures);
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -909,7 +909,7 @@ const routes: ServerRoute[] = [
 
         let assessmentMeasureId;
 
-        if (assessmentMeasure.AssessmentMeasure) {
+        if (assessmentMeasure.AssessmentMeasure && incomingAdditionalMeasures) {
           assessmentMeasureId = assessmentMeasure.AssessmentMeasure.id
           incomingAdditionalMeasures.id = assessmentMeasureId;
         }


### PR DESCRIPTION
Changes the `create` AssessmentMeasure to an `upsert` and modifies the patch endpoint to use the correct `id` so the `upsert` works.

Needed for https://github.com/Scottish-Natural-Heritage/Licensing/issues/1240