### PR TITLE
Fix copy paste mistake in cleaning function. Issue Licensing 1240

### DIFF
--- a/src/controllers/cleaning-functions.ts
+++ b/src/controllers/cleaning-functions.ts
@@ -443,7 +443,11 @@ const cleanAdditionalMeasure = (body: any): any => {
         : body.additionalMeasuresIntendToTry.scaringDevices
         ? 'Intend'
         : 'No',
-      hawking: body.measuresToContinue.hawking ? 'Continue' : body.additionalMeasuresIntendToTry.hawking ? 'Intend' : 'No',
+      hawking: body.measuresToContinue.hawking
+        ? 'Continue'
+        : body.additionalMeasuresIntendToTry.hawking
+        ? 'Intend'
+        : 'No',
       disturbanceByDogs: body.measuresToContinue.disturbanceByDogs
         ? 'Continue'
         : body.additionalMeasuresIntendToTry.disturbanceByDogs

--- a/src/controllers/cleaning-functions.ts
+++ b/src/controllers/cleaning-functions.ts
@@ -443,7 +443,7 @@ const cleanAdditionalMeasure = (body: any): any => {
         : body.additionalMeasuresIntendToTry.scaringDevices
         ? 'Intend'
         : 'No',
-      hawking: body.measuresToContinue.hawking ? 'Tried' : body.additionalMeasuresIntendToTry.hawking ? 'Intend' : 'No',
+      hawking: body.measuresToContinue.hawking ? 'Continue' : body.additionalMeasuresIntendToTry.hawking ? 'Intend' : 'No',
       disturbanceByDogs: body.measuresToContinue.disturbanceByDogs
         ? 'Continue'
         : body.additionalMeasuresIntendToTry.disturbanceByDogs


### PR DESCRIPTION
Bugfix UAT from issue https://github.com/Scottish-Natural-Heritage/Licensing/issues/1240

Addresses https://github.com/Scottish-Natural-Heritage/Licensing/issues/1240#issuecomment-1119570255 where the `hawking` value was not being correctly cleaned.