### PR TITLE
Add ternery to resend email notify personalisation for test3Assessment

### DIFF
--- a/src/controllers/license.ts
+++ b/src/controllers/license.ts
@@ -68,7 +68,9 @@ const setLicenceNotificationDetails = (application: any, licence: any) => {
     optionalReportingConditionsList: createReportingOptionalConditionsList(application.License.LicenseConditions),
     test1Details: application.ApplicationAssessment.testOneAssessment,
     test2Details: application.ApplicationAssessment.testTwoAssessment,
-    test3Details: application.ApplicationAssessment.testThreeAssessment,
+    test3Details: application.ApplicationAssessment.testThreeAssessment
+      ? application.ApplicationAssessment.testThreeAssessment
+      : '',
   };
 };
 


### PR DESCRIPTION
Issue https://github.com/Scottish-Natural-Heritage/Licensing/issues/1294

Adds a ternery check for the existence of `test3Assessment` as it might not exist and will break the Notify API call if it's `null`.