### PR TITLE
Change amendReason and assessment columns from string to text

### DIFF
--- a/util/db/migrations/20220615132244-change-amend-string-column-types-to-text.js
+++ b/util/db/migrations/20220615132244-change-amend-string-column-types-to-text.js
@@ -1,0 +1,50 @@
+/* eslint-disable unicorn/prefer-module */
+const databaseConfig = require('../database.js');
+
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.changeColumn(
+      {
+        schema: databaseConfig.database.schema,
+        tableName: 'Amendments',
+      },
+      'amendReason',
+      {
+        type: Sequelize.TEXT,
+      },
+    );
+    await queryInterface.changeColumn(
+      {
+        schema: databaseConfig.database.schema,
+        tableName: 'Amendments',
+      },
+      'assessment',
+      {
+        type: Sequelize.TEXT,
+      },
+    );
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.changeColumn(
+      {
+        schema: databaseConfig.database.schema,
+        tableName: 'Amendments',
+      },
+      'assessment',
+      {
+        type: Sequelize.STRING,
+      },
+    );
+    await queryInterface.changeColumn(
+      {
+        schema: databaseConfig.database.schema,
+        tableName: 'Amendments',
+      },
+      'amendReason',
+      {
+        type: Sequelize.STRING,
+      },
+    );
+  }
+};


### PR DESCRIPTION
Changes the amendReason and assessment columns from type `string` to type `text` to allow for data larger than 255 bytes or characters (can't remember which).