### PR TITLE
Add pretest script to package.json No issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "start": "node dist/server.js",
     "premigrations": "npx sequelize-cli db:migrate --env preMigrations --migrations-path util/db/pre-migrations",
     "migrations": "npx sequelize-cli db:migrate --env database",
-    "prestart": "npm run build && npm run migrations",
+    "prestart": "npm run migrations",
+    "pretest": "npm run build && npm run migrations",
     "test": "UNDER_TEST=true start-server-and-test start http://localhost:3017/gulls-health-and-safety-api/v1/ nm:run",
     "nm:run": "UNDER_TEST=true newman run tests/v1-gulls-health-and-safety-api.postman_collection.json"
   },


### PR DESCRIPTION
The `build` command in the prestart script was causing the start-up of the API to silently fail as the TypeScript compiler is not included in the Docker image. This PR moves the `build` to a pretest script.