### PR TITLE
Fix missing wildlife centre in notify email

### DIFF
--- a/src/controllers/returns.ts
+++ b/src/controllers/returns.ts
@@ -75,7 +75,7 @@ const addReturnActivities = (activities: any, speciesType: string): string => {
   if (activities.chicksToRescueCentre) {
     returnActivities.push(
       `${speciesType} - ${String(activities.quantityChicksToRescue)} chicks taken to ${String(
-        activities.rescueCentre,
+        activities.wildlifeCentre,
       )} on ${MultiUseFunctions.createShortDisplayDate(new Date(activities.dateChicksToRescue))}`,
     );
   }


### PR DESCRIPTION
Issue https://github.com/Scottish-Natural-Heritage/Licensing/issues/1378.

The string passed to notify on a return had an incorrect variable name for `wildlifeCentre` and was passing `undefined`. This PR corrects this.