### PR TITLE
Feature/add optional recording condition

### DIFF
--- a/src/controllers/license.ts
+++ b/src/controllers/license.ts
@@ -27,11 +27,11 @@ interface LicenseInterface {
 /**
  * Replaces `\\n` in a string with single `\n`.
  *
- * @param {string} str The string to swap any occurrence of `\\n` for `\n`.
- * @returns {string} Returns the modified string.
+ * @param {string} inputString The string to swap any occurrence of `\\n` for `\n`.
+ * @returns {string} Returns the modified string with any `\\n` replaced by `\n`.
  */
-const replaceDoubleSlashWithSingle = (str: string): string => {
-  return str.replace(/\\n/g, '\n');
+const replaceDoubleSlashWithSingle = (inputString: string): string => {
+  return inputString.replace(/\\n/g, '\n');
 };
 
 /**

--- a/src/controllers/license.ts
+++ b/src/controllers/license.ts
@@ -68,12 +68,50 @@ const setLicenceNotificationDetails = async (application: any, licence: any): Pr
     ),
     optionalGeneralConditionsList: await createGeneralOptionalConditionsList(application.License.LicenseConditions),
     optionalReportingConditionsList: await createReportingOptionalConditionsList(application.License.LicenseConditions),
+    defaultLicenceCoversConditionsList: await createDefaultConditionsList('What the licence covers'),
+    defaultWhatYouMustDoConditionsList: await createDefaultConditionsList('What you must do'),
+    defaultReportingConditionsList: await createDefaultConditionsList('Recording and reporting'),
+    defaultGeneralConditionsList: await createDefaultConditionsList('General'),
+    defaultAdvisoriesList: await createDefaultAdvisoriesList(),
     test1Details: application.ApplicationAssessment.testOneAssessment,
     test2Details: application.ApplicationAssessment.testTwoAssessment,
     test3Details: application.ApplicationAssessment.testThreeAssessment
       ? application.ApplicationAssessment.testThreeAssessment
       : '',
   };
+};
+
+const createDefaultConditionsList = async (category: string): Promise<string> => {
+  // Get all default conditions from the database.
+  const allDefaultConditions = await ConditionController.findAllDefault();
+
+  // Filter so we only have the desired category of default conditions.
+  const selectedDefaultConditions = allDefaultConditions.filter((condition) => {
+    return condition.category === category;
+  });
+
+  // Add each condition to an array.
+  const conditions = [];
+  for (const condition of selectedDefaultConditions) {
+    conditions.push(condition.condition);
+  }
+
+  // Return conditions as a single string of conditions, separated by newlines.
+  return conditions.join('\n');
+};
+
+const createDefaultAdvisoriesList = async (): Promise<string> => {
+  // Get all default advisories from the database.
+  const allDefaultAdvisories = await AdvisoryController.findAllDefault();
+
+  // Add each advisory to an array.
+  const advisories = [];
+  for (const advisory of allDefaultAdvisories) {
+    advisories.push(advisory.advisory);
+  }
+
+  // Return advisories as a single string of conditions, separated by newlines.
+  return advisories.join('\n');
 };
 
 /**

--- a/src/controllers/license.ts
+++ b/src/controllers/license.ts
@@ -25,6 +25,16 @@ interface LicenseInterface {
 }
 
 /**
+ * Replaces `\\n` in a string with single `\n`.
+ *
+ * @param {string} str The string to swap any occurrence of `\\n` for `\n`.
+ * @returns {string} Returns the modified string.
+ */
+const replaceDoubleSlashWithSingle = (str: string): string => {
+  return str.replace(/\\n/g, '\n');
+};
+
+/**
  * This function creates a personalisation object to be used by the notify API to create
  * the licence email.
  *
@@ -70,7 +80,7 @@ const setLicenceNotificationDetails = async (application: any, licence: any): Pr
     optionalReportingConditionsList: await createReportingOptionalConditionsList(application.License.LicenseConditions),
     defaultLicenceCoversConditionsList: await createDefaultConditionsList('What the licence covers'),
     defaultWhatYouMustDoConditionsList: await createDefaultConditionsList('What you must do'),
-    defaultReportingConditionsList: await createDefaultConditionsList('Recording and reporting'),
+    defaultReportingConditionsList: await createDefaultConditionsList('Recording and reporting requirements'),
     defaultGeneralConditionsList: await createDefaultConditionsList('General'),
     defaultAdvisoriesList: await createDefaultAdvisoriesList(),
     test1Details: application.ApplicationAssessment.testOneAssessment,
@@ -97,7 +107,7 @@ const createDefaultConditionsList = async (category: string): Promise<string> =>
   }
 
   // Return conditions as a single string of conditions, separated by newlines.
-  return conditions.join('\n');
+  return replaceDoubleSlashWithSingle(conditions.join('\n\n'));
 };
 
 const createDefaultAdvisoriesList = async (): Promise<string> => {
@@ -111,11 +121,11 @@ const createDefaultAdvisoriesList = async (): Promise<string> => {
   }
 
   // Return advisories as a single string of conditions, separated by newlines.
-  return advisories.join('\n');
+  return replaceDoubleSlashWithSingle(advisories.join('\n\n'));
 };
 
 /**
- * This function calls the Notify API and asks for an email to be send with the supplied details.
+ * This function calls the Notify API and asks for an email to be sent with the supplied details.
  *
  * @param {any} emailDetails The details to use in the email to be sent.
  * @param {any} emailAddress The email address to send the email to.
@@ -123,10 +133,14 @@ const createDefaultAdvisoriesList = async (): Promise<string> => {
 const sendLicenceNotificationEmail = async (emailDetails: any, emailAddress: any) => {
   if (config.notifyApiKey) {
     const notifyClient = new NotifyClient(config.notifyApiKey);
-    await notifyClient.sendEmail('8d995630-dd7b-4bb9-9678-1ad921e70e22', emailAddress, {
-      personalisation: emailDetails,
-      emailReplyToId: '4b49467e-2a35-4713-9d92-809c55bf1cdd',
-    });
+    try {
+      await notifyClient.sendEmail('5535b0a4-19b2-45db-844f-5b99edda8657', emailAddress, {
+        personalisation: emailDetails,
+        emailReplyToId: '4b49467e-2a35-4713-9d92-809c55bf1cdd',
+      });
+    } catch (error) {
+      console.log('ERROR: ' + error);
+    }
   }
 };
 

--- a/src/controllers/license.ts
+++ b/src/controllers/license.ts
@@ -133,14 +133,10 @@ const createDefaultAdvisoriesList = async (): Promise<string> => {
 const sendLicenceNotificationEmail = async (emailDetails: any, emailAddress: any) => {
   if (config.notifyApiKey) {
     const notifyClient = new NotifyClient(config.notifyApiKey);
-    try {
-      await notifyClient.sendEmail('5535b0a4-19b2-45db-844f-5b99edda8657', emailAddress, {
-        personalisation: emailDetails,
-        emailReplyToId: '4b49467e-2a35-4713-9d92-809c55bf1cdd',
-      });
-    } catch (error) {
-      console.log('ERROR: ' + error);
-    }
+    await notifyClient.sendEmail('5535b0a4-19b2-45db-844f-5b99edda8657', emailAddress, {
+      personalisation: emailDetails,
+      emailReplyToId: '4b49467e-2a35-4713-9d92-809c55bf1cdd',
+    });
   }
 };
 

--- a/util/db/migrations/20230127130649-insert-new-optional-recording-condition.js
+++ b/util/db/migrations/20230127130649-insert-new-optional-recording-condition.js
@@ -1,0 +1,21 @@
+/* eslint-disable unicorn/prefer-module */
+module.exports = {
+  up: async (queryInterface) => {
+    await queryInterface.bulkInsert('Conditions', [
+      {
+        id: 27,
+        condition: 'You must provide an activity or site return immediately after each site visit.',
+        orderNumber: 27,
+        default: false,
+        category: 'Recording and reporting requirements',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+  },
+  down: async (queryInterface, Sequelize) => {
+    // eslint-disable-next-line prefer-destructuring
+    const Op = Sequelize.Op;
+    await queryInterface.bulkDelete('Conditions', {id: {[Op.in]: [27]}}, {truncate: true});
+  },
+};

--- a/util/db/migrations/20230131123356-update-some-condition-text.js
+++ b/util/db/migrations/20230131123356-update-some-condition-text.js
@@ -4,7 +4,7 @@ if (process.env.NODE_ENV === 'production') {
   module.exports = {
     up: async (queryInterface, Sequelize) => {
       const updatedCondition1 =
-        'You must employ non-licensable measures first. If these are unsuccessful, then you must use a hierarchical approach to licensed control: \n\n 1. clearance of nests, then; \n 2. destruction or replacement of eggs, then; \n 3. taking of chicks, then; \n 4. killing of chicks, then; \n 5. killing of adults \n\n  ...only where each activity is permitted under this licence.';
+        'You must employ non-licensable measures first. If these are unsuccessful, then you must use a hierarchical approach to licensed control: \\n\\n 1. clearance of nests, then; \\n 2. destruction or replacement of eggs, then; \\n 3. taking of chicks, then; \\n 4. killing of chicks, then; \\n 5. killing of adults \\n\\n  ...only where each activity is permitted under this licence.';
 
       await queryInterface.sequelize.query(`UPDATE gulls."Conditions" SET "condition" = ? WHERE "id" = 8;`, {
         replacements: [updatedCondition1],
@@ -12,7 +12,7 @@ if (process.env.NODE_ENV === 'production') {
       });
 
       const updatedCondition2 =
-        'This licence only authorises where there is no other satisfactory course of action: \n\n - the species, activities and numbers listed on this licence \n - at the location specified \n - and during the period stated on this licence.';
+        'This licence only authorises where there is no other satisfactory course of action: \\n\\n - the species, activities and numbers listed on this licence \\n - at the location specified \\n - and during the period stated on this licence.';
 
       await queryInterface.sequelize.query(`UPDATE gulls."Conditions" SET "condition" = ? WHERE "id" = 1;`, {
         replacements: [updatedCondition2],
@@ -42,7 +42,7 @@ if (process.env.NODE_ENV === 'production') {
   module.exports = {
     up: async (queryInterface, Sequelize) => {
       const updatedCondition1 =
-        'You must employ non-licensable measures first. If these are unsuccessful, then you must use a hierarchical approach to licensed control: \n\n 1. clearance of nests, then; \n 2. destruction or replacement of eggs, then; \n 3. taking of chicks, then; \n 4. killing of chicks, then; \n 5. killing of adults \n\n  ...only where each activity is permitted under this licence.';
+        'You must employ non-licensable measures first. If these are unsuccessful, then you must use a hierarchical approach to licensed control: \\n\\n 1. clearance of nests, then; \\n 2. destruction or replacement of eggs, then; \\n 3. taking of chicks, then; \\n 4. killing of chicks, then; \\n 5. killing of adults \\n\\n  ...only where each activity is permitted under this licence.';
 
       await queryInterface.sequelize.query(`UPDATE Conditions SET condition = ? WHERE id = 8;`, {
         replacements: [updatedCondition1],
@@ -50,7 +50,7 @@ if (process.env.NODE_ENV === 'production') {
       });
 
       const updatedCondition2 =
-        'This licence only authorises where there is no other satisfactory course of action: \n\n - the species, activities and numbers listed on this licence \n - at the location specified \n - and during the period stated on this licence.';
+        'This licence only authorises where there is no other satisfactory course of action: \\n\\n - the species, activities and numbers listed on this licence \\n - at the location specified \\n - and during the period stated on this licence.';
 
       await queryInterface.sequelize.query(`UPDATE Conditions SET condition = ? WHERE id = 1;`, {
         replacements: [updatedCondition2],
@@ -60,7 +60,7 @@ if (process.env.NODE_ENV === 'production') {
 
     down: async (queryInterface, Sequelize) => {
       const revertedCondition2 =
-        'This licence only authorises where there is no other satisfactory course of action: \n\n - the species, activities and numbers listed on this licence \n - at the location specified \n - and during the period stated on this licence.';
+        'This licence only authorises where there is no other satisfactory course of action: \\n\\n - the species, activities and numbers listed on this licence \\n - at the location specified \\n - and during the period stated on this licence.';
 
       await queryInterface.sequelize.query(`UPDATE Conditions SET condition = ? WHERE id = 1;`, {
         replacements: [revertedCondition2],
@@ -68,7 +68,7 @@ if (process.env.NODE_ENV === 'production') {
       });
 
       const revertedCondition1 =
-        'You must employ non-licensable measures first. If these are unsuccessful, then you must use a hierarchical approach to licensed control: \n\n 1. clearance of nests, then; \n 2. destruction or replacement of eggs, then; \n 3. taking of chicks, then; \n 4. killing of chicks, then; \n 5. killing of adults \n\n  ...only where each activity is permitted under this licence.';
+        'You must employ non-licensable measures first. If these are unsuccessful, then you must use a hierarchical approach to licensed control: \\n\\n 1. clearance of nests, then; \\n 2. destruction or replacement of eggs, then; \\n 3. taking of chicks, then; \\n 4. killing of chicks, then; \\n 5. killing of adults \\n\\n  ...only where each activity is permitted under this licence.';
 
       await queryInterface.sequelize.query(`UPDATE Conditions SET condition = ? WHERE id = 8;`, {
         replacements: [revertedCondition1],

--- a/util/db/migrations/20230131123356-update-some-condition-text.js
+++ b/util/db/migrations/20230131123356-update-some-condition-text.js
@@ -18,7 +18,6 @@ if (process.env.NODE_ENV === 'production') {
         replacements: [updatedCondition2],
         type: Sequelize.QueryTypes.UPDATE,
       });
-
     },
 
     down: async (queryInterface, Sequelize) => {
@@ -37,8 +36,6 @@ if (process.env.NODE_ENV === 'production') {
         replacements: [revertedCondition1],
         type: Sequelize.QueryTypes.UPDATE,
       });
-
-
     },
   };
 } else {
@@ -59,8 +56,6 @@ if (process.env.NODE_ENV === 'production') {
         replacements: [updatedCondition2],
         type: Sequelize.QueryTypes.UPDATE,
       });
-
-
     },
 
     down: async (queryInterface, Sequelize) => {
@@ -79,8 +74,6 @@ if (process.env.NODE_ENV === 'production') {
         replacements: [revertedCondition1],
         type: Sequelize.QueryTypes.UPDATE,
       });
-
-
     },
   };
 }

--- a/util/db/migrations/20230131123356-update-some-condition-text.js
+++ b/util/db/migrations/20230131123356-update-some-condition-text.js
@@ -1,0 +1,86 @@
+/* eslint-disable unicorn/prefer-module */
+
+if (process.env.NODE_ENV === 'production') {
+  module.exports = {
+    up: async (queryInterface, Sequelize) => {
+      const updatedCondition1 =
+        'You must employ non-licensable measures first. If these are unsuccessful, then you must use a hierarchical approach to licensed control: \n\n 1. clearance of nests, then; \n 2. destruction or replacement of eggs, then; \n 3. taking of chicks, then; \n 4. killing of chicks, then; \n 5. killing of adults \n\n  ...only where each activity is permitted under this licence.';
+
+      await queryInterface.sequelize.query(`UPDATE gulls."Conditions" SET "condition" = ? WHERE "id" = 8;`, {
+        replacements: [updatedCondition1],
+        type: Sequelize.QueryTypes.UPDATE,
+      });
+
+      const updatedCondition2 =
+        'This licence only authorises where there is no other satisfactory course of action: \n\n - the species, activities and numbers listed on this licence \n - at the location specified \n - and during the period stated on this licence.';
+
+      await queryInterface.sequelize.query(`UPDATE gulls."Conditions" SET "condition" = ? WHERE "id" = 1;`, {
+        replacements: [updatedCondition2],
+        type: Sequelize.QueryTypes.UPDATE,
+      });
+
+    },
+
+    down: async (queryInterface, Sequelize) => {
+      const revertedCondition2 =
+        'This licence only authorises where there is no other satisfactory course of action: the species, activities and numbers listed on this licence, at the location specified and during the period stated on this licence.';
+
+      await queryInterface.sequelize.query(`UPDATE gulls."Conditions" SET "condition" = ? WHERE "id" = 1;`, {
+        replacements: [revertedCondition2],
+        type: Sequelize.QueryTypes.UPDATE,
+      });
+
+      const revertedCondition1 =
+        'You must employ non-licensable measures first. If these are unsuccessful, then you must use a hierarchical approach to licensed control: clearance of nests, then; destruction or replacement of eggs, then; taking of chicks, then; killing of chicks, then; killing of adults - only where each activity is permitted under this licence.';
+
+      await queryInterface.sequelize.query(`UPDATE gulls."Conditions" SET "condition" = ? WHERE "id" = 8;`, {
+        replacements: [revertedCondition1],
+        type: Sequelize.QueryTypes.UPDATE,
+      });
+
+
+    },
+  };
+} else {
+  module.exports = {
+    up: async (queryInterface, Sequelize) => {
+      const updatedCondition1 =
+        'You must employ non-licensable measures first. If these are unsuccessful, then you must use a hierarchical approach to licensed control: \n\n 1. clearance of nests, then; \n 2. destruction or replacement of eggs, then; \n 3. taking of chicks, then; \n 4. killing of chicks, then; \n 5. killing of adults \n\n  ...only where each activity is permitted under this licence.';
+
+      await queryInterface.sequelize.query(`UPDATE Conditions SET condition = ? WHERE id = 8;`, {
+        replacements: [updatedCondition1],
+        type: Sequelize.QueryTypes.UPDATE,
+      });
+
+      const updatedCondition2 =
+        'This licence only authorises where there is no other satisfactory course of action: \n\n - the species, activities and numbers listed on this licence \n - at the location specified \n - and during the period stated on this licence.';
+
+      await queryInterface.sequelize.query(`UPDATE Conditions SET condition = ? WHERE id = 1;`, {
+        replacements: [updatedCondition2],
+        type: Sequelize.QueryTypes.UPDATE,
+      });
+
+
+    },
+
+    down: async (queryInterface, Sequelize) => {
+      const revertedCondition2 =
+        'This licence only authorises where there is no other satisfactory course of action: \n\n - the species, activities and numbers listed on this licence \n - at the location specified \n - and during the period stated on this licence.';
+
+      await queryInterface.sequelize.query(`UPDATE Conditions SET condition = ? WHERE id = 1;`, {
+        replacements: [revertedCondition2],
+        type: Sequelize.QueryTypes.UPDATE,
+      });
+
+      const revertedCondition1 =
+        'You must employ non-licensable measures first. If these are unsuccessful, then you must use a hierarchical approach to licensed control: \n\n 1. clearance of nests, then; \n 2. destruction or replacement of eggs, then; \n 3. taking of chicks, then; \n 4. killing of chicks, then; \n 5. killing of adults \n\n  ...only where each activity is permitted under this licence.';
+
+      await queryInterface.sequelize.query(`UPDATE Conditions SET condition = ? WHERE id = 8;`, {
+        replacements: [revertedCondition1],
+        type: Sequelize.QueryTypes.UPDATE,
+      });
+
+
+    },
+  };
+}

--- a/util/db/migrations/20230131123356-update-some-condition-text.js
+++ b/util/db/migrations/20230131123356-update-some-condition-text.js
@@ -60,7 +60,7 @@ if (process.env.NODE_ENV === 'production') {
 
     down: async (queryInterface, Sequelize) => {
       const revertedCondition2 =
-        'This licence only authorises where there is no other satisfactory course of action: \\n\\n - the species, activities and numbers listed on this licence \\n - at the location specified \\n - and during the period stated on this licence.';
+        'This licence only authorises where there is no other satisfactory course of action: the species, activities and numbers listed on this licence, at the location specified and during the period stated on this licence.';
 
       await queryInterface.sequelize.query(`UPDATE Conditions SET condition = ? WHERE id = 1;`, {
         replacements: [revertedCondition2],
@@ -68,7 +68,7 @@ if (process.env.NODE_ENV === 'production') {
       });
 
       const revertedCondition1 =
-        'You must employ non-licensable measures first. If these are unsuccessful, then you must use a hierarchical approach to licensed control: \\n\\n 1. clearance of nests, then; \\n 2. destruction or replacement of eggs, then; \\n 3. taking of chicks, then; \\n 4. killing of chicks, then; \\n 5. killing of adults \\n\\n  ...only where each activity is permitted under this licence.';
+        'You must employ non-licensable measures first. If these are unsuccessful, then you must use a hierarchical approach to licensed control: clearance of nests, then; destruction or replacement of eggs, then; taking of chicks, then; killing of chicks, then; killing of adults - only where each activity is permitted under this licence.';
 
       await queryInterface.sequelize.query(`UPDATE Conditions SET condition = ? WHERE id = 8;`, {
         replacements: [revertedCondition1],

--- a/util/db/migrations/20230131130248-replace-existing-reporting-condition.js
+++ b/util/db/migrations/20230131130248-replace-existing-reporting-condition.js
@@ -1,0 +1,151 @@
+/* eslint-disable unicorn/prefer-module */
+
+if (process.env.NODE_ENV === 'production') {
+  module.exports = {
+    up: async (queryInterface, Sequelize) => {
+      // Grab the condition as a object.
+      const condition1 = await queryInterface.sequelize.query('SELECT * FROM gulls."Conditions" WHERE "id" = 11;', {
+        type: Sequelize.QueryTypes.SELECT,
+      });
+
+      // Mark it as deleted.
+      condition1[0].deletedAt = new Date();
+
+      await queryInterface.sequelize.query(`UPDATE gulls."Conditions" SET "deletedAt" = ? WHERE "id" = ?;`, {
+        replacements: [condition1[0].deletedAt, condition1[0].id],
+        type: Sequelize.QueryTypes.UPDATE,
+      });
+
+      // Grab the condition as a object.
+      const condition2 = await queryInterface.sequelize.query('SELECT * FROM gulls."Conditions" WHERE "id" = 18;', {
+        type: Sequelize.QueryTypes.SELECT,
+      });
+
+      // Mark it as deleted.
+      condition2[0].deletedAt = new Date();
+
+      await queryInterface.sequelize.query(`UPDATE gulls."Conditions" SET "deletedAt" = ? WHERE "id" = ?;`, {
+        replacements: [condition2[0].deletedAt, condition2[0].id],
+        type: Sequelize.QueryTypes.UPDATE,
+      });
+
+      await queryInterface.bulkInsert('Conditions', [
+        {
+          id: 28,
+          condition:
+            'You must provide these details as activity, site and final returns to NatureScot within one month of this licence expiring or otherwise coming to an end.',
+          orderNumber: 28,
+          default: true,
+          category: 'Recording and reporting requirements',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ]);
+    },
+    down: async (queryInterface, Sequelize) => {
+      // eslint-disable-next-line prefer-destructuring
+      const Op = Sequelize.Op;
+      await queryInterface.bulkDelete('Conditions', {id: {[Op.in]: [28]}}, {truncate: true});
+
+      // Grab the condition as a object.
+      const condition2 = await queryInterface.sequelize.query('SELECT * FROM gulls."Conditions" WHERE "id" = 18;', {
+        type: Sequelize.QueryTypes.SELECT,
+      });
+
+      // Mark it as no longer deleted.
+      condition2[0].deletedAt = null;
+
+      await queryInterface.sequelize.query(`UPDATE gulls."Conditions" SET "deletedAt" = ? WHERE "id" = ?;`, {
+        replacements: [condition2[0].deletedAt, condition2[0].id],
+        type: Sequelize.QueryTypes.UPDATE,
+      });
+
+      // Grab the condition as a object.
+      const condition1 = await queryInterface.sequelize.query('SELECT * FROM gulls."Conditions" WHERE "id" = 11;', {
+        type: Sequelize.QueryTypes.SELECT,
+      });
+
+      // Mark it as no longer deleted.
+      condition1[0].deletedAt = null;
+
+      await queryInterface.sequelize.query(`UPDATE gulls."Conditions" SET "deletedAt" = ? WHERE "id" = ?;`, {
+        replacements: [condition1[0].deletedAt, condition1[0].id],
+        type: Sequelize.QueryTypes.UPDATE,
+      });
+    },
+  };
+} else {
+  module.exports = {
+    up: async (queryInterface, Sequelize) => {
+      // Grab the condition as a object.
+      const condition1 = await queryInterface.sequelize.query('SELECT * FROM Conditions WHERE id = 18;', {
+        type: Sequelize.QueryTypes.SELECT,
+      });
+
+      // Mark it as deleted.
+      condition1[0].deletedAt = new Date();
+
+      await queryInterface.sequelize.query(`UPDATE Conditions SET deletedAt = ? WHERE id = ?;`, {
+        replacements: [condition1[0].deletedAt, condition1[0].id],
+        type: Sequelize.QueryTypes.UPDATE,
+      });
+
+      // Grab the condition as a object.
+      const condition2 = await queryInterface.sequelize.query('SELECT * FROM Conditions WHERE id = 18;', {
+        type: Sequelize.QueryTypes.SELECT,
+      });
+
+      // Mark it as deleted.
+      condition2[0].deletedAt = new Date();
+
+      await queryInterface.sequelize.query(`UPDATE Conditions SET deletedAt = ? WHERE id = ?;`, {
+        replacements: [condition2[0].deletedAt, condition2[0].id],
+        type: Sequelize.QueryTypes.UPDATE,
+      });
+
+      await queryInterface.bulkInsert('Conditions', [
+        {
+          id: 28,
+          condition:
+            'You must provide these details as activity, site and final returns to NatureScot within one month of this licence expiring or otherwise coming to an end.',
+          orderNumber: 28,
+          default: true,
+          category: 'Recording and reporting requirements',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ]);
+    },
+    down: async (queryInterface, Sequelize) => {
+      // eslint-disable-next-line prefer-destructuring
+      const Op = Sequelize.Op;
+      await queryInterface.bulkDelete('Conditions', {id: {[Op.in]: [28]}}, {truncate: true});
+
+      // Grab the condition as a object.
+      const condition2 = await queryInterface.sequelize.query('SELECT * FROM Conditions WHERE id = 18;', {
+        type: Sequelize.QueryTypes.SELECT,
+      });
+
+      // Mark it as no longer deleted.
+      condition2[0].deletedAt = null;
+
+      await queryInterface.sequelize.query(`UPDATE Conditions SET deletedAt = ? WHERE id = ?;`, {
+        replacements: [condition2[0].deletedAt, condition2[0].id],
+        type: Sequelize.QueryTypes.UPDATE,
+      });
+
+      // Grab the condition as a object.
+      const condition1 = await queryInterface.sequelize.query('SELECT * FROM Conditions WHERE id = 18;', {
+        type: Sequelize.QueryTypes.SELECT,
+      });
+
+      // Mark it as no longer deleted.
+      condition1[0].deletedAt = null;
+
+      await queryInterface.sequelize.query(`UPDATE Conditions SET deletedAt = ? WHERE id = ?;`, {
+        replacements: [condition1[0].deletedAt, condition1[0].id],
+        type: Sequelize.QueryTypes.UPDATE,
+      });
+    },
+  };
+}

--- a/util/db/migrations/20230131130248-replace-existing-reporting-condition.js
+++ b/util/db/migrations/20230131130248-replace-existing-reporting-condition.js
@@ -78,7 +78,7 @@ if (process.env.NODE_ENV === 'production') {
   module.exports = {
     up: async (queryInterface, Sequelize) => {
       // Grab the condition as a object.
-      const condition1 = await queryInterface.sequelize.query('SELECT * FROM Conditions WHERE id = 18;', {
+      const condition1 = await queryInterface.sequelize.query('SELECT * FROM Conditions WHERE id = 11;', {
         type: Sequelize.QueryTypes.SELECT,
       });
 
@@ -135,7 +135,7 @@ if (process.env.NODE_ENV === 'production') {
       });
 
       // Grab the condition as a object.
-      const condition1 = await queryInterface.sequelize.query('SELECT * FROM Conditions WHERE id = 18;', {
+      const condition1 = await queryInterface.sequelize.query('SELECT * FROM Conditions WHERE id = 11;', {
         type: Sequelize.QueryTypes.SELECT,
       });
 


### PR DESCRIPTION
Part of issues:
https://github.com/Scottish-Natural-Heritage/Licensing/issues/1723
https://github.com/Scottish-Natural-Heritage/Licensing/issues/1722

Adds a new optional condition, and updates some existing default conditions with `\n` to allow for them to be displayed in both the gulls-staff preview page and the Notify email when they're pulled from the DB (instead of the current hard-coded entries). Also updates an existing condition by marking the (two) previous entries as (soft) deleted and adding the new condition.