### PR TITLE
Feature/1493 revert filters

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1821,9 +1821,8 @@ const routes: ServerRoute[] = [
         const currentDate = new Date();
 
         // Today's date minus 21 days.
-        let currentDateMinusTwentyOneDays = currentDate
-        currentDateMinusTwentyOneDays.setDate(currentDate.getDate()-21);
-      
+        const currentDateMinusTwentyOneDays: Date = new Date(new Date().setDate(new Date().getDate() - 21));
+
         // Fetch all applications to be filtered.
         const applications = await Scheduled.findAllApplicantsNoReturnCurrentSeason();
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1821,8 +1821,9 @@ const routes: ServerRoute[] = [
         const currentDate = new Date();
 
         // Today's date minus 21 days.
-        // const todayDateMinusTwentyOneDays: Date = new Date(new Date().setDate(new Date().getDate() - 21));
-
+        let currentDateMinusTwentyOneDays = currentDate
+        currentDateMinusTwentyOneDays.setDate(currentDate.getDate()-21);
+      
         // Fetch all applications to be filtered.
         const applications = await Scheduled.findAllApplicantsNoReturnCurrentSeason();
 
@@ -1834,12 +1835,11 @@ const routes: ServerRoute[] = [
             // Checks active licence
             application.License?.periodTo > currentDate &&
             // Checks it was created more than 3 weeks ago
-            // new Date(application.License?.periodFrom) <= todayDateMinusTwentyOneDays &&
+            new Date(application.License?.periodFrom) <= currentDateMinusTwentyOneDays &&
             // No returns
-            application.License?.Returns === null &&
+            application.License?.Returns.length === 0 &&
             // No revoked or withdrawn licenses
             application.Revocation === null &&
-            application.Withdrawal === null &&
             // Checks valid PActivity criteria of eggDestruction or removeNests
             checkForValidActivities(application?.PSpecies)
           );

--- a/src/server.ts
+++ b/src/server.ts
@@ -89,7 +89,7 @@ cron.schedule('0 6 * * *', async () => {
 });
 
 // Cron scheduled tasks, set to trigger at 6am each day.
-cron.schedule('30 10 * * *', async () => {
+cron.schedule('00 12 * * *', async () => {
   console.log('Triggering test cron job(s).');
   // Check for licences at least 3 weeks old without a return and send out a reminder on the 1st of every month.
   try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -89,7 +89,7 @@ cron.schedule('0 6 * * *', async () => {
 });
 
 // Cron scheduled tasks, set to trigger at 6am each day.
-cron.schedule('00 16 * * *', async () => {
+cron.schedule('30 10 * * *', async () => {
   console.log('Triggering test cron job(s).');
   // Check for licences at least 3 weeks old without a return and send out a reminder on the 1st of every month.
   try {


### PR DESCRIPTION
Notify templates have been investigated, it was found that there was a build difference between those on Notify and the draft ones on Sharepoint, the one on Notify differs by having just a ((name)) rather than ((laName)),((lhName))

- **src/routes.ts** - reverts filter to original state
- **src/server.ts** - cron to fire at midday to give time for UAT environment to build with new code. 

Issue: Scottish-Natural-Heritage/Licensing#1493