### PR TITLE
feature/revert-changes-to-advisories

### DIFF
--- a/util/db/migrations/20240801125337-undo-advisory-replacement.js
+++ b/util/db/migrations/20240801125337-undo-advisory-replacement.js
@@ -1,0 +1,49 @@
+/* eslint-disable unicorn/prefer-module */
+
+if (process.env.NODE_ENV === 'production') {
+  module.exports = {
+    up: async (queryInterface, Sequelize) => {
+      // prettier-ignore
+      const updatedAdvisory1 =
+        'This licence is granted subject to compliance with the conditions as specified. Anything done otherwise than in accordance with the terms of this licence may constitute an offence.';
+
+      await queryInterface.sequelize.query(`UPDATE gulls."Advisories" SET "advisory" = ? WHERE "id" = 3;`, {
+        replacements: [updatedAdvisory1],
+        type: Sequelize.QueryTypes.UPDATE,
+      });
+    },
+
+    down: async (queryInterface, Sequelize) => {
+      const updatedAdvisory1 =
+        'This licence is granted subject to compliance with the conditions as specified. Anything done otherwise than in accordance with the terms of the licence may constitute an offence. It is the responsibility of the licence holder, agents and assistants working under this licence to report to NatureScot any breaches of the licence conditions that they become aware of as soon as is reasonably possible.';
+
+      await queryInterface.sequelize.query(`UPDATE gulls."Advisories" SET "advisory" = ? WHERE "id" = 3;`, {
+        replacements: [updatedAdvisory1],
+        type: Sequelize.QueryTypes.UPDATE,
+      });
+    },
+  };
+} else {
+  module.exports = {
+    up: async (queryInterface, Sequelize) => {
+      // prettier-ignore
+      const updatedAdvisory1 =
+        'This licence is granted subject to compliance with the conditions as specified. Anything done otherwise than in accordance with the terms of this licence may constitute an offence.';
+
+      await queryInterface.sequelize.query(`UPDATE Advisories SET advisory = ? WHERE id = 3;`, {
+        replacements: [updatedAdvisory1],
+        type: Sequelize.QueryTypes.UPDATE,
+      });
+    },
+
+    down: async (queryInterface, Sequelize) => {
+      const updatedAdvisory1 =
+        'This licence is granted subject to compliance with the conditions as specified. Anything done otherwise than in accordance with the terms of the licence may constitute an offence. It is the responsibility of the licence holder, agents and assistants working under this licence to report to NatureScot any breaches of the licence conditions that they become aware of as soon as is reasonably possible.';
+
+      await queryInterface.sequelize.query(`UPDATE Advisories SET advisory = ? WHERE id = 3;`, {
+        replacements: [updatedAdvisory1],
+        type: Sequelize.QueryTypes.UPDATE,
+      });
+    },
+  };
+}

--- a/util/db/migrations/20240801125905-undo-advisory-addition.js
+++ b/util/db/migrations/20240801125905-undo-advisory-addition.js
@@ -1,0 +1,23 @@
+/* eslint-disable unicorn/prefer-module */
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    // prettier-ignore
+    // eslint-disable-next-line prefer-destructuring
+    const Op = Sequelize.Op
+    await queryInterface.bulkDelete('Advisories', {id: {[Op.in]: [9]}});
+  },
+  down: async (queryInterface) => {
+    // prettier-ignore
+    await queryInterface.bulkInsert('Advisories', [
+      {
+        id: 9,
+        advisory:
+          'It is the responsibility of the licence holder to ensure that all contact details are up to date. Not advising NatureScot of changes to licence holder contact details could result in the licence being revoked.',
+        orderNumber: 9,
+        default: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+  },
+};


### PR DESCRIPTION
This PR reverts some DB changes made a while back that have been sitting on `develop` and are not yet ready for production, and are blocking a deployment to `main`. No issue raised.