### PR TITLE
feature/8-create-health-check-endpoint

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -83,6 +83,17 @@ const routes: ServerRoute[] = [
   },
 
   /**
+   * Health-check endpoint.
+   */
+  {
+    method: 'get',
+    path: `${config.pathPrefix}/health`,
+    handler: (_request: Request, h: ResponseToolkit) => {
+      return h.response({message: 'OK'}).code(200);
+    },
+  },
+
+  /**
    * GET all advisories endpoint.
    */
   {


### PR DESCRIPTION
Adds a server route on the `/health` path that returns a 200 OK when hit with a GET.

Issue https://github.com/Scottish-Natural-Heritage/AWS-Cloud-Infrastructure-Review-Optimise-Standardise/issues/8.