### PR TITLE
Retention for withdrawn applications

### DIFF
--- a/src/controllers/application.ts
+++ b/src/controllers/application.ts
@@ -1370,6 +1370,10 @@ const ApplicationController = {
         await Assessment.destroy({where: {ApplicationId: id}, force: true, transaction: t});
         // Delete any assessment Measure attached to the application/license.
         await AssessmentMeasure.destroy({where: {ApplicationId: id}, force: true, transaction: t});
+        // Delete any Notes attached to the application.
+        await Note.destroy({where: {ApplicationId: id}, force: true, transaction: t});
+        // Delete any UploadedImages attached to the application.
+        await UploadedImage.destroy({where: {ApplicationId: id}, force: true, transaction: t});
 
         // Send the withdrawal email to the license holder.
         await sendWithdrawalEmail(emailDetails, application.LicenceHolder.emailAddress);

--- a/src/controllers/scheduled.ts
+++ b/src/controllers/scheduled.ts
@@ -617,6 +617,111 @@ const ScheduledController = {
   },
 
   /**
+   * Returns all refused, expired and revoked applications that are more than 5 years past
+   * their relevant terminal date and have not yet had retention applied.
+   *
+   * - Refused: 5 years past Assessment.updatedAt (when decision was set to false)
+   * - Expired: 5 years past License.periodTo, with no Revocation
+   * - Revoked: 5 years past Revocation.createdAt (Application is soft-deleted)
+   *
+   * @returns An array of applications past their retention period.
+   */
+  getApplicationsPastRetention: async () => {
+    const fiveYearsAgo: Date = new Date(new Date().setFullYear(new Date().getFullYear() - 5));
+
+    const [refused, expired, revoked] = await Promise.all([
+      // Refused: confirmed applications with a failed assessment, no licence issued
+      Application.findAll({
+        paranoid: true,
+        where: {
+          retentionAppliedAt: {[Op.is]: null},
+          '$ApplicationAssessment.decision$': false,
+          '$ApplicationAssessment.updatedAt$': {[Op.lte]: fiveYearsAgo},
+          '$License.ApplicationId$': {[Op.is]: null},
+        },
+        include: [
+          {model: Assessment, as: 'ApplicationAssessment', required: true},
+          {model: License, as: 'License', required: false},
+        ],
+        subQuery: false,
+      }),
+      // Expired: issued licences where periodTo is more than 5 years ago, not revoked
+      Application.findAll({
+        paranoid: true,
+        where: {
+          retentionAppliedAt: {[Op.is]: null},
+          '$License.periodTo$': {[Op.lte]: fiveYearsAgo},
+          '$Revocation.ApplicationId$': {[Op.is]: null},
+        },
+        include: [
+          {model: License, as: 'License', required: true},
+          {model: Revocation, as: 'Revocation', required: false},
+        ],
+        subQuery: false,
+      }),
+      // Revoked: soft-deleted applications with a Revocation more than 5 years ago
+      Application.findAll({
+        paranoid: false,
+        where: {
+          deletedAt: {[Op.not]: null},
+          retentionAppliedAt: {[Op.is]: null},
+          '$Revocation.createdAt$': {[Op.lte]: fiveYearsAgo},
+        },
+        include: [{model: Revocation, as: 'Revocation', required: true}],
+        subQuery: false,
+      }),
+    ]);
+
+    return [...refused, ...expired, ...revoked];
+  },
+
+  /**
+   * Redacts PII from contact and address records for a refused, expired or revoked application,
+   * hard-deletes its officer notes, then marks it as having had retention applied.
+   *
+   * Uses paranoid: false on updates to handle revoked applications whose records are soft-deleted.
+   *
+   * @param {any} application The application to apply retention to.
+   */
+  applyRetentionToApplication: async (application: any): Promise<void> => {
+    const contactIds = [...new Set([application.LicenceHolderId, application.LicenceApplicantId])].filter(Boolean);
+    const addressIds = [...new Set([application.LicenceHolderAddressId, application.SiteAddressId])].filter(Boolean);
+
+    await database.sequelize.transaction(async (t: any) => {
+      if (contactIds.length > 0) {
+        await Contact.update(
+          {
+            name: 'retained',
+            organisation: null,
+            emailAddress: 'retained@example.com',
+            phoneNumber: null,
+          },
+          {where: {id: contactIds}, paranoid: false, transaction: t},
+        );
+      }
+
+      if (addressIds.length > 0) {
+        await Address.update(
+          {
+            addressLine1: 'retained',
+            addressLine2: null,
+            addressTown: 'retained',
+            addressCounty: null,
+          },
+          {where: {id: addressIds}, paranoid: false, transaction: t},
+        );
+      }
+
+      await Note.destroy({where: {ApplicationId: application.id}, force: true, transaction: t});
+
+      await Application.update(
+        {retentionAppliedAt: new Date()},
+        {where: {id: application.id}, paranoid: false, transaction: t},
+      );
+    });
+  },
+
+  /**
    * Returns all confirmed, undetermined (unassigned or in-progress) applications whose last
    * transaction (Application.updatedAt) was more than 6 months ago and have not yet had
    * retention applied.

--- a/src/controllers/scheduled.ts
+++ b/src/controllers/scheduled.ts
@@ -713,6 +713,7 @@ const ScheduledController = {
       }
 
       await Note.destroy({where: {ApplicationId: application.id}, force: true, transaction: t});
+      await UploadedImage.destroy({where: {ApplicationId: application.id}, force: true, transaction: t});
 
       await Application.update(
         {retentionAppliedAt: new Date()},

--- a/src/controllers/scheduled.ts
+++ b/src/controllers/scheduled.ts
@@ -22,8 +22,20 @@ import {ApplicationInterface} from './application.js';
 /* eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, unicorn/prefer-module, prefer-destructuring */
 const NotifyClient = require('notifications-node-client').NotifyClient;
 
-const {Application, Assessment, Contact, Address, License, Revocation, Returns, Withdrawal, PSpecies, PActivity} =
-  database;
+const {
+  Application,
+  Assessment,
+  Contact,
+  Address,
+  License,
+  Note,
+  Revocation,
+  Returns,
+  Withdrawal,
+  UploadedImage,
+  PSpecies,
+  PActivity,
+} = database;
 
 /**
  * This function calls the Notify API and asks for a 14 day reminder email to be sent to
@@ -576,6 +588,32 @@ const ScheduledController = {
 
     // Return the unconfirmed array of applications or undefined if empty.
     return unconfirmed ? (unconfirmed as ApplicationInterface[]) : undefined;
+  },
+
+  /**
+   * Hard-deletes any Notes and UploadedImages still attached to withdrawn applications.
+   * 
+   * This is only needed to handle applications withdrawn before Note and UploadedImage deletion was added to the
+   * withdraw function.
+   * 
+   * TODO: Once any previous applications have been cleaned up, this function can be removed.
+   *
+   * @returns {number} The number of withdrawn applications processed.
+   */
+  cleanupWithdrawnApplications: async (): Promise<number> => {
+    const withdrawals = await Withdrawal.findAll({attributes: ['ApplicationId']});
+    const applicationIds: number[] = withdrawals
+      .map((w) => {
+        return w.ApplicationId;
+      })
+      .filter(Boolean);
+
+    if (applicationIds.length === 0) return 0;
+
+    await Note.destroy({where: {ApplicationId: applicationIds}, force: true});
+    await UploadedImage.destroy({where: {ApplicationId: applicationIds}, force: true});
+
+    return applicationIds.length;
   },
 
   /**

--- a/src/controllers/scheduled.ts
+++ b/src/controllers/scheduled.ts
@@ -691,9 +691,9 @@ const ScheduledController = {
       if (contactIds.length > 0) {
         await Contact.update(
           {
-            name: 'retained',
+            name: 'No data',
             organisation: null,
-            emailAddress: 'retained@example.com',
+            emailAddress: 'no.data@example.com', // this is value needed to pass validation in src/models/contact.ts,  ContactModel: isEmail: true
             phoneNumber: null,
           },
           {where: {id: contactIds}, paranoid: false, transaction: t},
@@ -703,9 +703,9 @@ const ScheduledController = {
       if (addressIds.length > 0) {
         await Address.update(
           {
-            addressLine1: 'retained',
+            addressLine1: 'No data',
             addressLine2: null,
-            addressTown: 'retained',
+            addressTown: 'No data',
             addressCounty: null,
           },
           {where: {id: addressIds}, paranoid: false, transaction: t},
@@ -769,9 +769,9 @@ const ScheduledController = {
     await database.sequelize.transaction(async (t: any) => {
       await Contact.update(
         {
-          name: 'retained',
+          name: 'No data',
           organisation: null,
-          emailAddress: 'retained@example.com',
+          emailAddress: 'No data',
           phoneNumber: null,
         },
         {where: {id: contactIds}, transaction: t},
@@ -779,9 +779,9 @@ const ScheduledController = {
 
       await Address.update(
         {
-          addressLine1: 'retained',
+          addressLine1: 'No data',
           addressLine2: null,
-          addressTown: 'retained',
+          addressTown: 'No data',
           addressCounty: null,
         },
         {where: {id: addressIds}, transaction: t},

--- a/src/controllers/scheduled.ts
+++ b/src/controllers/scheduled.ts
@@ -656,7 +656,7 @@ const ScheduledController = {
    *
    * @param {any} application The application to apply retention to.
    */
-  applyRetentionToApplication: async (application: any): Promise<void> => {
+  applyRetentionToUndeterminedApplication: async (application: any): Promise<void> => {
     const contactIds = [...new Set([application.LicenceHolderId, application.LicenceApplicantId])];
     const addressIds = [...new Set([application.LicenceHolderAddressId, application.SiteAddressId])];
 

--- a/src/models/contact.ts
+++ b/src/models/contact.ts
@@ -41,6 +41,8 @@ const ContactModel = (sequelize: Sequelize) => {
         type: DataTypes.STRING,
         validate: {
           notEmpty: true,
+           // TODO: we may want to remove email address validation in favour of an application-level check 
+           // so that, when retention is applied, this field can be set to "No data", in line with other applications.
           isEmail: true,
         },
       },

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -838,6 +838,34 @@ const routes: ServerRoute[] = [
   },
 
   /**
+   * Apply retention policy to refused, expired and revoked applications (5 years past their
+   * terminal date). Redacts PII from contacts and addresses, hard-deletes officer notes,
+   * and stamps retentionAppliedAt.
+   */
+  {
+    method: 'post',
+    path: `${config.pathPrefix}/apply-terminal-retention`,
+    handler: async (request: Request, h: ResponseToolkit) => {
+      try {
+        const applications = await Scheduled.getApplicationsPastRetention();
+
+        /* eslint-disable no-await-in-loop */
+        for (const application of applications) {
+          await Scheduled.applyRetentionToApplication(application);
+        }
+        /* eslint-enable no-await-in-loop */
+
+        return h
+          .response({message: `Retention applied to ${applications.length} terminal application(s).`})
+          .code(200);
+      } catch (error: unknown) {
+        request.logger.error(JsonUtils.unErrorJson(error));
+        return h.response({error}).code(500);
+      }
+    },
+  },
+
+  /**
    * Apply retention policy to withdrawn applications by hard-deleting any Notes and
    * UploadedImages still attached.
    * 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -873,7 +873,7 @@ const routes: ServerRoute[] = [
 
         /* eslint-disable no-await-in-loop */
         for (const application of applications) {
-          await Scheduled.applyRetentionToApplication(application);
+          await Scheduled.applyRetentionToUndeterminedApplication(application);
         }
         /* eslint-enable no-await-in-loop */
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -838,6 +838,29 @@ const routes: ServerRoute[] = [
   },
 
   /**
+   * Apply retention policy to withdrawn applications by hard-deleting any Notes and
+   * UploadedImages still attached.
+   * 
+   * This is only needed to handle applications withdrawn before Note and UploadedImage deletion was added to the
+   * withdraw function.
+   * 
+   * TODO: Once any previously-withdrawn applications have been cleaned up, this function can be removed.
+   */
+  {
+    method: 'post',
+    path: `${config.pathPrefix}/apply-withdrawn-retention`,
+    handler: async (request: Request, h: ResponseToolkit) => {
+      try {
+        const count = await Scheduled.cleanupWithdrawnApplications();
+        return h.response({message: `Withdrawn retention cleanup processed ${count} application(s).`}).code(200);
+      } catch (error: unknown) {
+        request.logger.error(JsonUtils.unErrorJson(error));
+        return h.response({error}).code(500);
+      }
+    },
+  },
+
+  /**
    * Apply retention policy to undetermined (unassigned and in-progress) applications
    * whose last transaction was more than 6 months ago.
    */

--- a/src/server.ts
+++ b/src/server.ts
@@ -93,6 +93,18 @@ cron.schedule('0 6 * * *', async () => {
     console.error(JsonUtils.unErrorJson(error));
   }
 
+  /**
+   * This is only needed to handle applications withdrawn before Note and UploadedImage deletion was added to the
+   * withdraw function.
+   * 
+   * TODO: Once any previously-withdrawn applications have been cleaned up, this function can be removed.
+   */
+  try {
+    await axios.post(`http://localhost:${config.gullsApiPort}${config.pathPrefix}/apply-withdrawn-retention`);
+  } catch (error: unknown) {
+    console.error(JsonUtils.unErrorJson(error));
+  }
+
   console.log('Ending cron job(s).');
 });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -96,7 +96,7 @@ cron.schedule('0 6 * * *', async () => {
   /**
    * This is only needed to handle applications withdrawn before Note and UploadedImage deletion was added to the
    * withdraw function.
-   * 
+   *
    * TODO: Once any previously-withdrawn applications have been cleaned up, this function can be removed.
    */
   try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -88,6 +88,12 @@ cron.schedule('0 6 * * *', async () => {
   // Retention cron jobs
 
   try {
+    await axios.post(`http://localhost:${config.gullsApiPort}${config.pathPrefix}/apply-terminal-retention`);
+  } catch (error: unknown) {
+    console.error(JsonUtils.unErrorJson(error));
+  }
+
+  try {
     await axios.post(`http://localhost:${config.gullsApiPort}${config.pathPrefix}/apply-undetermined-retention`);
   } catch (error: unknown) {
     console.error(JsonUtils.unErrorJson(error));


### PR DESCRIPTION
Note: this PR builds on #206 

Adds deletion of Note and UploadedImage when an application is withdrawn.

Adds (temporary) scheduled job to clean up any existing withdrawn applications. This can be removed once withdrawn applicationsl are up to date.
